### PR TITLE
Setup devenv Configuration with Scripts

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -5,11 +5,21 @@
     claude-code
     gh
     trunk
+    wasm-bindgen-cli
   ];
 
   languages.rust = {
     enable = true;
     channel = "stable";
     targets = ["wasm32-unknown-unknown"];
+  };
+
+  scripts = {
+    dev.exec = "trunk serve";
+    build.exec = "trunk build --release";
+    fmt.exec = "cargo fmt";
+    fmt-check.exec = "cargo fmt -- --check";
+    lint.exec = "cargo clippy -- -D warnings";
+    test.exec = "cargo test";
   };
 }

--- a/devenv.nix
+++ b/devenv.nix
@@ -1,5 +1,11 @@
 {pkgs, ...}: {
-  packages = with pkgs; [git spec-kit claude-code gh trunk];
+  packages = with pkgs; [
+    git
+    spec-kit
+    claude-code
+    gh
+    trunk
+  ];
 
   languages.rust = {
     enable = true;

--- a/devenv.nix
+++ b/devenv.nix
@@ -17,8 +17,8 @@
   scripts = {
     dev.exec = "trunk serve";
     build.exec = "trunk build --release";
-    fmt.exec = "cargo fmt";
-    fmt-check.exec = "cargo fmt -- --check";
+    format.exec = "cargo fmt";
+    format-check.exec = "cargo fmt -- --check";
     lint.exec = "cargo clippy -- -D warnings";
     test.exec = "cargo test";
   };


### PR DESCRIPTION
Description:

Create devenv.nix configuration for reproducible development environment with Rust, Trunk, and named scripts for local/CI parity.

Acceptance Criteria:

devenv.nix configures Rust stable toolchain

Trunk and wasm-bindgen-cli installed via devenv

Named scripts defined: dev, lint, test, fmt, fmt-check, build

devenv shell enters environment successfully

All devenv scripts work (e.g., devenv shell lint)

devenv.lock committed for reproducibility