### PR TITLE
fix(ralph): remove erroneous -- from devenv shell invocations

### DIFF
--- a/scripts/ralph.sh
+++ b/scripts/ralph.sh
@@ -79,9 +79,9 @@ ${TRUNCATED_CONTEXT}"
 
     if CLAUDE_OUT=$(devcontainer exec --workspace-folder "$WORKTREE" \
         -e CLAUDE_CODE_OAUTH_TOKEN="${CLAUDE_CODE_OAUTH_TOKEN:-}" \
-        -- devenv shell -- claude --print --dangerously-skip-permissions -p "$FULL_PROMPT" 2>&1); then
+        -- devenv shell claude --print --dangerously-skip-permissions -p "$FULL_PROMPT" 2>&1); then
 
-      if TEST_OUT=$(devcontainer exec --workspace-folder "$WORKTREE" -- devenv shell -- devenv test 2>&1); then
+      if TEST_OUT=$(devcontainer exec --workspace-folder "$WORKTREE" -- devenv shell devenv test 2>&1); then
         backlog task edit "$SUBTASK_ID" --status "Done"
         ERROR_CONTEXT=""
         break


### PR DESCRIPTION
## Summary

- `devenv shell -- <cmd>` launches an interactive shell instead of running the specified command
- Fixed by removing the `--` separator on both `devenv shell` invocations in `ralph.sh`

## Test plan

- [ ] Run ralph against a task and confirm Claude executes non-interactively inside the devcontainer
- [ ] Confirm `devenv test` runs non-interactively on success

🤖 Generated with [Claude Code](https://claude.com/claude-code)