### PR TITLE
fix(#82): exclude today's sets from Previous Sessions panel

### DIFF
--- a/public/db-module.js
+++ b/public/db-module.js
@@ -37,6 +37,12 @@ export async function initDatabase(fileData) {
       db = new SQL.Database();
     }
 
+    // Expose a global test hook so E2E tests can run raw SQL without
+    // going through the Rust/WASM layer (e.g. to backdate timestamps).
+    if (typeof window !== "undefined") {
+      window.__dbExecuteQuery = (sql, params) => executeQuery(sql, params);
+    }
+
     return true;
   } catch (error) {
     console.error("Failed to initialize database:", error);

--- a/public/db-module.js
+++ b/public/db-module.js
@@ -37,9 +37,11 @@ export async function initDatabase(fileData) {
       db = new SQL.Database();
     }
 
-    // Expose a global test hook so E2E tests can run raw SQL without
-    // going through the Rust/WASM layer (e.g. to backdate timestamps).
-    if (typeof window !== "undefined") {
+    // Expose a raw SQL hook only when the test harness has flagged this as a
+    // test environment (window.__TEST_MODE__ = true is set via addInitScript
+    // in the Playwright fixture before the page loads). This ensures the hook
+    // is never present in production builds.
+    if (typeof window !== "undefined" && window.__TEST_MODE__) {
       window.__dbExecuteQuery = (sql, params) => executeQuery(sql, params);
     }
 

--- a/src/components/previous_sessions.rs
+++ b/src/components/previous_sessions.rs
@@ -5,10 +5,24 @@ use dioxus::prelude::*;
 use wasm_bindgen::prelude::*;
 use web_sys::{IntersectionObserver, IntersectionObserverEntry, IntersectionObserverInit};
 
-// Include all sets regardless of date (finished sessions from today are still "previous").
-const ALL_SETS_CUTOFF_MS: f64 = f64::MAX;
-
 const PAGE_SIZE: i64 = 20;
+
+/// Returns the UTC timestamp (Unix ms) for midnight at the start of the current
+/// local calendar day.  Sets recorded on or after this value belong to today and
+/// must not appear in the Previous Sessions panel.
+///
+/// The calculation follows the same logic used in the database tests:
+/// 1. Obtain the device's UTC offset from `Date.getTimezoneOffset()` (minutes,
+///    negated so east-of-UTC is positive).
+/// 2. Shift `Date.now()` by that offset to obtain a "local-time epoch".
+/// 3. Truncate to a whole day, then shift back to get UTC midnight for today.
+fn start_of_today_utc_ms() -> f64 {
+    let now_ms = js_sys::Date::now();
+    // getTimezoneOffset() returns minutes *west* of UTC, so negate to get east.
+    let offset_ms = -(js_sys::Date::new_0().get_timezone_offset() as f64) * 60_000.0;
+    let local_now_ms = now_ms + offset_ms;
+    (local_now_ms / 86_400_000.0).floor() * 86_400_000.0 - offset_ms
+}
 
 /// Collapsible "Previous Sessions" panel shown inside the active workout view.
 ///
@@ -47,7 +61,7 @@ pub fn PreviousSessions(
             loading.set(true);
             if let Some(db) = state.database() {
                 match db
-                    .get_sets_for_exercise_before(eid, ALL_SETS_CUTOFF_MS, PAGE_SIZE, offset)
+                    .get_sets_for_exercise_before(eid, start_of_today_utc_ms(), PAGE_SIZE, offset)
                     .await
                 {
                     Ok(mut new_sets) => {
@@ -86,7 +100,7 @@ pub fn PreviousSessions(
             loading.set(true);
             if let Some(db) = state.database() {
                 match db
-                    .get_sets_for_exercise_before(eid, ALL_SETS_CUTOFF_MS, PAGE_SIZE, 0)
+                    .get_sets_for_exercise_before(eid, start_of_today_utc_ms(), PAGE_SIZE, 0)
                     .await
                 {
                     Ok(new_sets) => {

--- a/src/components/previous_sessions.rs
+++ b/src/components/previous_sessions.rs
@@ -19,7 +19,7 @@ const PAGE_SIZE: i64 = 20;
 fn start_of_today_utc_ms() -> f64 {
     let now_ms = js_sys::Date::now();
     // getTimezoneOffset() returns minutes *west* of UTC, so negate to get east.
-    let offset_ms = -(js_sys::Date::new_0().get_timezone_offset() as f64) * 60_000.0;
+    let offset_ms = -js_sys::Date::new_0().get_timezone_offset() * 60_000.0;
     let local_now_ms = now_ms + offset_ms;
     (local_now_ms / 86_400_000.0).floor() * 86_400_000.0 - offset_ms
 }

--- a/tests/e2e/features/previous_sessions.feature
+++ b/tests/e2e/features/previous_sessions.feature
@@ -18,10 +18,10 @@ Feature: Collapsible Previous Sessions in active workout
     When I tap the "Previous Sessions" header
     Then the "Previous Sessions" section should be collapsed
 
-  Scenario: Logged set appears in history feed immediately
+  Scenario: Completed previous-day session sets appear in history feed
     Given I start a test session with "Deadlift"
-    When I log a set in the current session
-    And I tap the "Previous Sessions" header
+    And I have logged 1 sets for "Deadlift" in a previous session
+    When I tap the "Previous Sessions" header
     Then the history feed should contain at least 1 set
 
   Scenario: Load more button loads the next page when history is long
@@ -33,13 +33,13 @@ Feature: Collapsible Previous Sessions in active workout
     When I click the "Load more" button
     Then the history feed should contain 25 sets
 
-  Scenario: History feed updates reactively when a set is logged while the section is expanded
+  Scenario: History feed shows only previous-day sets while current-day sets are excluded
     Given I start a test session with "Deadlift"
     And I have logged 3 sets for "Deadlift" in a previous session
     When I tap the "Previous Sessions" header
     Then the history feed should contain 3 sets
     When I log a set in the current session
-    Then the history feed should contain 4 sets
+    Then the history feed should contain 3 sets
 
   Scenario: Expanded section shows Set, Reps, and RPE column headers
     Given I start a test session with "Deadlift"

--- a/tests/e2e/steps/fixtures.ts
+++ b/tests/e2e/steps/fixtures.ts
@@ -2,6 +2,17 @@ import { test as base } from "playwright-bdd";
 import { expect } from "@playwright/test";
 import { createBdd } from "playwright-bdd";
 
-export const test = base.extend<{}>({});
+// Extend the base fixture to inject window.__TEST_MODE__ = true before any
+// page scripts execute. This allows db-module.js to register the raw SQL
+// hook (window.__dbExecuteQuery) exclusively in test runs, keeping it out
+// of production builds.
+export const test = base.extend<{}>({
+  page: async ({ page }, use) => {
+    await page.addInitScript(() => {
+      (window as unknown as Record<string, unknown>).__TEST_MODE__ = true;
+    });
+    await use(page);
+  },
+});
 export const { Given, When, Then } = createBdd(test);
 export { expect };

--- a/tests/e2e/steps/previous_sessions.steps.ts
+++ b/tests/e2e/steps/previous_sessions.steps.ts
@@ -147,7 +147,8 @@ Given(
     // start-of-today cutoff used by the Previous Sessions panel.
     // The panel only shows sets with recorded_at < midnight(today, local tz).
     // window.__dbExecuteQuery is registered by db-module.js after initDatabase()
-    // and shares the same db instance as the running app.
+    // only when window.__TEST_MODE__ === true (set by the Playwright fixture).
+    // It shares the same db instance as the running app.
     await page.evaluate(async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const exec = (window as any).__dbExecuteQuery as

--- a/tests/e2e/steps/previous_sessions.steps.ts
+++ b/tests/e2e/steps/previous_sessions.steps.ts
@@ -142,5 +142,22 @@ Given(
     await page.waitForSelector('body[data-hydrated="true"]', {
       timeout: 10000,
     });
+
+    // Backdate the persisted sets to yesterday so they appear before the
+    // start-of-today cutoff used by the Previous Sessions panel.
+    // The panel only shows sets with recorded_at < midnight(today, local tz).
+    await page.evaluate(async () => {
+      const mod = await import("/db-module.js");
+      const oneDayMs = 86_400_000;
+      const now = Date.now();
+      const offsetMs = -new Date().getTimezoneOffset() * 60_000;
+      const startOfTodayUtc =
+        Math.floor((now + offsetMs) / oneDayMs) * oneDayMs - offsetMs;
+      // Shift every set recorded today (>= start-of-today) back by one full day.
+      await mod.executeQuery(
+        "UPDATE completed_sets SET recorded_at = recorded_at - ? WHERE recorded_at >= ?",
+        [oneDayMs, startOfTodayUtc],
+      );
+    });
   },
 );

--- a/tests/e2e/steps/previous_sessions.steps.ts
+++ b/tests/e2e/steps/previous_sessions.steps.ts
@@ -146,15 +146,21 @@ Given(
     // Backdate the persisted sets to yesterday so they appear before the
     // start-of-today cutoff used by the Previous Sessions panel.
     // The panel only shows sets with recorded_at < midnight(today, local tz).
+    // window.__dbExecuteQuery is registered by db-module.js after initDatabase()
+    // and shares the same db instance as the running app.
     await page.evaluate(async () => {
-      const mod = await import("/db-module.js");
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const exec = (window as any).__dbExecuteQuery as
+        | ((sql: string, params: unknown[]) => Promise<unknown>)
+        | undefined;
+      if (!exec) throw new Error("__dbExecuteQuery not available on window");
       const oneDayMs = 86_400_000;
       const now = Date.now();
       const offsetMs = -new Date().getTimezoneOffset() * 60_000;
       const startOfTodayUtc =
         Math.floor((now + offsetMs) / oneDayMs) * oneDayMs - offsetMs;
       // Shift every set recorded today (>= start-of-today) back by one full day.
-      await mod.executeQuery(
+      await exec(
         "UPDATE completed_sets SET recorded_at = recorded_at - ? WHERE recorded_at >= ?",
         [oneDayMs, startOfTodayUtc],
       );

--- a/tests/e2e/steps/previous_sessions.steps.ts
+++ b/tests/e2e/steps/previous_sessions.steps.ts
@@ -2,13 +2,6 @@ import { Given, When, Then, expect } from "./fixtures";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-/** Returns the collapse content div inside the Previous Sessions panel. */
-function historyContent(page: import("@playwright/test").Page) {
-  return page.locator(
-    '[data-testid="previous-sessions"] [data-testid="previous-sessions-content"]',
-  );
-}
-
 /** Returns every set row in the expanded history feed. */
 function historyRows(page: import("@playwright/test").Page) {
   return page.locator('[data-testid="previous-sessions-content"] tbody tr');


### PR DESCRIPTION
Closes #82

## What was changed

Removed the `ALL_SETS_CUTOFF_MS = f64::MAX` constant from `previous_sessions.rs` that caused every set in the database (including ones recorded earlier today) to appear in the Previous Sessions panel after clearing browser site data.

Restored the `start_of_today_utc_ms()` helper function which computes UTC midnight for the current local calendar day using `Date.getTimezoneOffset()`. This is now passed as the cutoff timestamp in both the initial page load and the infinite-scroll pagination call inside the `PreviousSessions` component.

## QA Checklist

- [x] After logging sets for an exercise, clearing browser site data, reopening the database, and navigating to the same exercise, the Previous Sessions panel shows zero sessions for that exercise
- [x] Sets recorded on a previous calendar day still appear correctly in the Previous Sessions panel after a normal app reload
- [ ] Sets recorded today that belong to an active in-memory session are not shown in the Previous Sessions panel
- [ ] When multiple sets exist in the database spanning multiple days, only sets from before the current calendar day are returned by the Previous Sessions query
- [ ] The `ALL_SETS_CUTOFF_MS` constant (or equivalent `f64::MAX` sentinel) no longer exists in the codebase
- [ ] All existing tests continue to pass with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)