### PR TITLE
fix: bottom navigation bar scrolls off screen when content exceeds viewport height

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -604,6 +604,12 @@ html {
   --b3: 92.4169% 0.00108 197.137559;
   --bc: 27.8078% 0.029596 256.847952;
 }
+  html,
+  body,
+  #main {
+    height: 100%;
+    overflow: hidden;
+  }
 .container {
   width: 100%;
 }
@@ -3102,6 +3108,9 @@ details.collapse summary::-webkit-details-marker {
 .h-auto {
   height: auto;
 }
+.h-screen {
+  height: 100vh;
+}
 .max-h-\[90dvh\] {
   max-height: 90dvh;
 }
@@ -3113,9 +3122,6 @@ details.collapse summary::-webkit-details-marker {
 }
 .min-h-8 {
   min-height: 2rem;
-}
-.min-h-screen {
-  min-height: 100vh;
 }
 .w-12 {
   width: 3rem;

--- a/src/app.rs
+++ b/src/app.rs
@@ -432,7 +432,7 @@ pub fn App() -> Element {
 
     rsx! {
         div {
-            class: "flex flex-col min-h-screen bg-base-200",
+            class: "flex flex-col h-screen bg-base-200",
             header {
                 class: "navbar bg-primary text-primary-content flex-none",
                 div {

--- a/src/styles.css
+++ b/src/styles.css
@@ -2,6 +2,15 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer base {
+  html,
+  body,
+  #main {
+    height: 100%;
+    overflow: hidden;
+  }
+}
+
 @layer utilities {
   .pb-safe-nav {
     padding-bottom: calc(5rem + env(safe-area-inset-bottom));

--- a/tests/e2e/features/tab_bar_layout.feature
+++ b/tests/e2e/features/tab_bar_layout.feature
@@ -1,0 +1,30 @@
+Feature: Tab bar stays fixed during scrolling
+  As a user with a lot of workout data
+  I want the bottom navigation bar to always be visible
+  So I can switch tabs without scrolling to the bottom
+
+  Background:
+    Given I have a fresh context and clear storage
+    And I create a new database
+
+  Scenario: Tab bar is visible when page content exceeds viewport height
+    Given the viewport is set to a small height of 400px
+    When I am on the workout page
+    Then the tab bar should be visible within the viewport
+
+  Scenario: Tab bar remains visible after scrolling through long content
+    Given the viewport is set to a small height of 400px
+    And there is enough content to scroll
+    When I scroll to the bottom of the content area
+    Then the tab bar should be visible within the viewport
+
+  Scenario: Page content area is independently scrollable
+    Given the viewport is set to a small height of 400px
+    And there is enough content to scroll
+    Then the content area should be scrollable
+    And the tab bar should be visible within the viewport
+
+  Scenario: Short content pages show no layout regression
+    When I am on the workout page
+    Then the tab bar should be visible within the viewport
+    And there should be no extra gap below the tab bar

--- a/tests/e2e/steps/tab_bar_layout.steps.ts
+++ b/tests/e2e/steps/tab_bar_layout.steps.ts
@@ -1,0 +1,100 @@
+import { Given, When, Then, expect } from "./fixtures";
+
+Given(
+  "the viewport is set to a small height of {int}px",
+  async ({ page }, height: number) => {
+    const currentSize = page.viewportSize();
+    const width = currentSize?.width ?? 1280;
+    await page.setViewportSize({ width, height });
+  },
+);
+
+Given("there is enough content to scroll", async ({ page }) => {
+  // Inject a tall element into the content area to force overflow
+  await page.waitForSelector('[data-testid="shell-content"]', {
+    timeout: 10000,
+  });
+  await page.evaluate(() => {
+    const content = document.querySelector(
+      '[data-testid="shell-content"]',
+    ) as HTMLElement;
+    if (content) {
+      const spacer = document.createElement("div");
+      spacer.style.height = "2000px";
+      spacer.setAttribute("data-testid", "scroll-spacer");
+      content.appendChild(spacer);
+    }
+  });
+});
+
+When("I am on the workout page", async ({ page }) => {
+  await page.waitForSelector('body[data-hydrated="true"]', { timeout: 10000 });
+});
+
+When(
+  "I scroll to the bottom of the content area",
+  async ({ page }) => {
+    await page.evaluate(() => {
+      const content = document.querySelector(
+        '[data-testid="shell-content"]',
+      ) as HTMLElement;
+      if (content) {
+        content.scrollTop = content.scrollHeight;
+      }
+    });
+    await page.waitForTimeout(200);
+  },
+);
+
+Then("the tab bar should be visible within the viewport", async ({ page }) => {
+  const tabList = page.locator('[role="tablist"]');
+  await expect(tabList).toBeVisible();
+
+  // Verify the tab bar is within the viewport bounds (not scrolled off screen)
+  const viewportHeight = page.viewportSize()?.height ?? 768;
+  const tabBarBoundingBox = await tabList.boundingBox();
+
+  expect(tabBarBoundingBox).not.toBeNull();
+  if (tabBarBoundingBox) {
+    // The bottom of the tab bar must be within the viewport
+    expect(tabBarBoundingBox.y).toBeGreaterThanOrEqual(0);
+    expect(tabBarBoundingBox.y + tabBarBoundingBox.height).toBeLessThanOrEqual(
+      viewportHeight + 1, // +1 for sub-pixel rounding
+    );
+  }
+});
+
+Then("the content area should be scrollable", async ({ page }) => {
+  const isScrollable = await page.evaluate(() => {
+    const content = document.querySelector(
+      '[data-testid="shell-content"]',
+    ) as HTMLElement;
+    if (!content) return false;
+    const style = window.getComputedStyle(content);
+    return (
+      style.overflowY === "auto" ||
+      style.overflowY === "scroll" ||
+      content.scrollHeight > content.clientHeight
+    );
+  });
+  expect(isScrollable).toBe(true);
+});
+
+Then(
+  "there should be no extra gap below the tab bar",
+  async ({ page }) => {
+    const viewportHeight = page.viewportSize()?.height ?? 768;
+    const tabBarBoundingBox = await page
+      .locator('[role="tablist"]')
+      .boundingBox();
+
+    expect(tabBarBoundingBox).not.toBeNull();
+    if (tabBarBoundingBox) {
+      // The tab bar bottom should be at or near the bottom of the viewport (within 50px tolerance for safe-area insets)
+      const distanceFromBottom =
+        viewportHeight -
+        (tabBarBoundingBox.y + tabBarBoundingBox.height);
+      expect(distanceFromBottom).toBeLessThanOrEqual(50);
+    }
+  },
+);


### PR DESCRIPTION
Closes #107

## Summary

The bottom navigation bar was scrolling off screen when page content exceeded the viewport height. This fix constrains the Shell layout to the exact viewport height so the tab bar stays pinned at the bottom while page content scrolls independently above it.

## Root Cause

Two issues combined to produce the bug:
1. The root App div used `min-h-screen` (= `min-height: 100vh`), allowing the flex container to grow beyond the viewport
2. `html`, `body`, and Dioxus's `#main` mount div had no height constraints, so the root div's `h-screen` (once applied) expanded to match their unconstrained height rather than the viewport

## Changes

- **`src/app.rs`**: Root App div changed from `min-h-screen` to `h-screen`
- **`src/styles.css`**: Added `@layer base { html, body, #main { height: 100%; overflow: hidden } }` to constrain the DOM ancestors so `h-screen` works correctly
- **`public/styles.css`**: Rebuilt output CSS (from `src/styles.css`)
- **`tests/e2e/features/tab_bar_layout.feature`**: New BDD feature file
- **`tests/e2e/steps/tab_bar_layout.steps.ts`**: New step definitions

## QA Checklist

- [x] The bottom navigation bar is visible at the bottom of the screen when page content exceeds the viewport height
- [x] Scrolling through long page content does not cause the navigation bar to scroll off screen
- [x] Page content scrolls independently above the navigation bar (the nav bar does not move)
- [x] Pages with short content (less than the viewport height) display correctly — no layout regression, no extra gaps
- [x] The safe area inset padding on the tab bar remains intact (nav bar is not obscured by device home indicator on mobile)
- [x] Switching between tabs while on a long-content page leaves the nav bar in the correct fixed position