### PR TITLE
Sync backend: metadata endpoint

### DIFF
--- a/sync-backend/src/app.ts
+++ b/sync-backend/src/app.ts
@@ -56,6 +56,35 @@ export function createApp(dataDir: string) {
     }
   });
 
+  app.get("/sync/:sync_id/metadata", async (c) => {
+    const syncId = c.req.param("sync_id");
+
+    if (!VALID_SYNC_ID.test(syncId)) {
+      return c.text("Invalid sync_id", 400);
+    }
+
+    const slotDir = join(dataDir, syncId);
+    const clockPath = join(slotDir, "clock.json");
+    const metaPath = join(slotDir, "meta.json");
+
+    try {
+      const clock = JSON.parse(await readFile(clockPath, "utf-8"));
+      const meta = JSON.parse(await readFile(metaPath, "utf-8"));
+
+      return c.json({
+        vector_clock: clock,
+        blob_size: meta.blob_size,
+        last_modified: meta.last_modified,
+        conflicted: false,
+      });
+    } catch (err: unknown) {
+      if (err instanceof Error && "code" in err && err.code === "ENOENT") {
+        return c.text("Not found", 404);
+      }
+      throw err;
+    }
+  });
+
   app.post("/sync/:sync_id", async (c) => {
     const syncId = c.req.param("sync_id");
 

--- a/sync-backend/src/app.ts
+++ b/sync-backend/src/app.ts
@@ -81,6 +81,9 @@ export function createApp(dataDir: string) {
       if (err instanceof Error && "code" in err && err.code === "ENOENT") {
         return c.text("Not found", 404);
       }
+      if (err instanceof SyntaxError) {
+        return c.text("Corrupt metadata", 500);
+      }
       throw err;
     }
   });
@@ -110,7 +113,7 @@ export function createApp(dataDir: string) {
       return c.text("Payload too large", 413);
     }
 
-    // Parse vector clock from header
+    // Parse and validate vector clock from header
     const clockHeader = c.req.header("X-Vector-Clock");
     let clock: Record<string, number> = {};
     if (clockHeader) {

--- a/sync-backend/test/sync-api.test.ts
+++ b/sync-backend/test/sync-api.test.ts
@@ -226,6 +226,46 @@ describe("sync API", () => {
     expect(socket.data).toContain("413");
   });
 
+  test("GET /sync/:sync_id/metadata returns 404 for a slot that has never been pushed", async () => {
+    const res = await fetch(`${baseUrl}/sync/no-such-slot/metadata`);
+    expect(res.status).toBe(404);
+  });
+
+  test("GET /sync/:sync_id/metadata returns correct JSON shape after push", async () => {
+    const blob = new Uint8Array([0xaa, 0xbb, 0xcc, 0xdd]);
+    const clock = { device_a: 3 };
+    const before = Date.now();
+
+    await fetch(`${baseUrl}/sync/metadata-test`, {
+      method: "POST",
+      body: blob,
+      headers: {
+        "Content-Type": "application/octet-stream",
+        "X-Vector-Clock": JSON.stringify(clock),
+      },
+    });
+
+    const after = Date.now();
+
+    const res = await fetch(`${baseUrl}/sync/metadata-test/metadata`);
+    expect(res.status).toBe(200);
+
+    const json = await res.json();
+
+    // vector_clock matches what was pushed
+    expect(json.vector_clock).toEqual(clock);
+
+    // blob_size matches byte length
+    expect(json.blob_size).toBe(4);
+
+    // last_modified is a Unix-millisecond timestamp within the push window
+    expect(json.last_modified).toBeGreaterThanOrEqual(before);
+    expect(json.last_modified).toBeLessThanOrEqual(after);
+
+    // conflicted is always false (hardcoded for now)
+    expect(json.conflicted).toBe(false);
+  });
+
   test("separate data directories are isolated from each other", async () => {
     const customDir = await mkdtemp(join(tmpdir(), "sync-custom-"));
     const customServer = startServer(customDir);

--- a/sync-backend/test/sync-api.test.ts
+++ b/sync-backend/test/sync-api.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createApp } from "../src/app.ts";
@@ -264,6 +264,16 @@ describe("sync API", () => {
 
     // conflicted is always false (hardcoded for now)
     expect(json.conflicted).toBe(false);
+  });
+
+  test("GET /sync/:sync_id/metadata returns 500 for corrupt clock.json", async () => {
+    const slotDir = join(dataDir, "corrupt-clock");
+    await mkdir(slotDir, { recursive: true });
+    await writeFile(join(slotDir, "clock.json"), "not-valid-json");
+    await writeFile(join(slotDir, "meta.json"), JSON.stringify({ blob_size: 1, last_modified: 0 }));
+
+    const res = await fetch(`${baseUrl}/sync/corrupt-clock/metadata`);
+    expect(res.status).toBe(500);
   });
 
   test("separate data directories are isolated from each other", async () => {

--- a/sync-backend/test/sync-api.test.ts
+++ b/sync-backend/test/sync-api.test.ts
@@ -270,7 +270,10 @@ describe("sync API", () => {
     const slotDir = join(dataDir, "corrupt-clock");
     await mkdir(slotDir, { recursive: true });
     await writeFile(join(slotDir, "clock.json"), "not-valid-json");
-    await writeFile(join(slotDir, "meta.json"), JSON.stringify({ blob_size: 1, last_modified: 0 }));
+    await writeFile(
+      join(slotDir, "meta.json"),
+      JSON.stringify({ blob_size: 1, last_modified: 0 }),
+    );
 
     const res = await fetch(`${baseUrl}/sync/corrupt-clock/metadata`);
     expect(res.status).toBe(500);


### PR DESCRIPTION
## Summary

- Add `GET /sync/:sync_id/metadata` endpoint that returns `vector_clock`, `blob_size`, `last_modified`, and `conflicted` (hardcoded `false`) without transferring the blob
- Returns 404 for non-existent slots
- Integration tests cover metadata after push and 404 for missing slot

Closes #119

## QA Checklist

<!-- From ralph-assess -->

- [ ] After pushing a blob with a vector clock, `GET /sync/:sync_id/metadata` returns 200 with a JSON body containing `vector_clock`, `blob_size`, `last_modified`, and `conflicted` fields
- [ ] The `vector_clock` value in the metadata response matches the clock that was sent in the most recent push
- [ ] The `blob_size` value matches the byte length of the most recently pushed blob
- [ ] The `last_modified` value is a Unix-millisecond timestamp reflecting the time of the most recent push
- [ ] The `conflicted` field is always `false`
- [ ] `GET /sync/:sync_id/metadata` for a sync_id that has never been pushed returns 404

## Test plan

- [x] Integration test: metadata endpoint returns 404 for non-existent slot
- [x] Integration test: after push, metadata returns correct vector_clock, blob_size, last_modified, and conflicted=false

🤖 Generated with [Claude Code](https://claude.com/claude-code)