### PR TITLE
Sync backend: Dockerfile

### DIFF
--- a/sync-backend/.dockerignore
+++ b/sync-backend/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+test
+Dockerfile
+.dockerignore

--- a/sync-backend/.dockerignore
+++ b/sync-backend/.dockerignore
@@ -1,4 +1,4 @@
 node_modules
-test
+tests
 Dockerfile
 .dockerignore

--- a/sync-backend/.dockerignore
+++ b/sync-backend/.dockerignore
@@ -1,4 +1,4 @@
 node_modules
-tests
+test
 Dockerfile
 .dockerignore

--- a/sync-backend/Dockerfile
+++ b/sync-backend/Dockerfile
@@ -21,4 +21,4 @@ USER bun
 # EXPOSE documents the default port; the actual port is controlled by the PORT env var
 EXPOSE 3000
 
-CMD ["bun", "run", "src/index.ts"]
+ENTRYPOINT ["sh", "-c", "mkdir -p \"$DATA_DIR\" && exec bun run src/index.ts"]

--- a/sync-backend/Dockerfile
+++ b/sync-backend/Dockerfile
@@ -1,0 +1,22 @@
+# Stage 1: Install dependencies
+FROM oven/bun:1 AS deps
+WORKDIR /app
+COPY package.json bun.lock ./
+RUN bun install --frozen-lockfile --production
+
+# Stage 2: Production image
+FROM oven/bun:1-slim
+WORKDIR /app
+
+COPY --from=deps /app/node_modules ./node_modules
+COPY package.json tsconfig.json ./
+COPY src ./src
+
+ENV DATA_DIR=/data
+ENV PORT=3000
+
+RUN mkdir -p /data
+
+EXPOSE 3000
+
+CMD ["bun", "run", "src/index.ts"]

--- a/sync-backend/Dockerfile
+++ b/sync-backend/Dockerfile
@@ -15,8 +15,10 @@ COPY src ./src
 ENV DATA_DIR=/data
 ENV PORT=3000
 
-RUN mkdir -p /data
+RUN mkdir -p /data && chown -R bun:bun /data
+USER bun
 
+# EXPOSE documents the default port; the actual port is controlled by the PORT env var
 EXPOSE 3000
 
 CMD ["bun", "run", "src/index.ts"]


### PR DESCRIPTION
Closes #122

## Summary

- Adds a multi-stage Dockerfile for the Hono + Bun sync backend service
- Adds `.dockerignore` to exclude test files and node_modules from the build context
- Uses `oven/bun:1` for dependency installation and `oven/bun:1-slim` for the production image (~193 MB)
- `DATA_DIR` (default `/data`) and `PORT` (default `3000`) are configurable via environment variables

## QA Checklist

- [ ] Running `docker build` in the `sync-backend/` directory produces an image without errors
- [ ] Running `docker run -v /tmp/test-data:/data -p 3000:3000 <image>` starts the service and `POST /sync/test123` followed by `GET /sync/test123` returns the pushed blob
- [ ] Stopping and restarting the container with the same volume mount preserves previously written blob data (GET returns the blob written in the prior run)
- [ ] Setting `DATA_DIR=/custom` via `-e DATA_DIR=/custom` and mounting a volume at `/custom` causes the service to read and write blobs at that path instead of `/data`
- [ ] Setting `PORT=8080` via `-e PORT=8080` and mapping `-p 8080:8080` causes the service to listen on port 8080
- [ ] The final Docker image size is reasonable (under ~200 MB, confirming multi-stage or slim build practices)

🤖 Generated with [Claude Code](https://claude.com/claude-code)