### PR TITLE
feat: schema migration — min_reps, max_reps, settings table

### DIFF
--- a/src/components/exercise_form.rs
+++ b/src/components/exercise_form.rs
@@ -92,6 +92,8 @@ pub fn ExerciseForm(
             } else {
                 SetTypeConfig::Bodyweight
             },
+            min_reps: initial_exercise.as_ref().map(|e| e.min_reps).unwrap_or(1),
+            max_reps: initial_exercise.as_ref().and_then(|e| e.max_reps),
         };
 
         on_save.call(exercise);

--- a/src/models/exercise.rs
+++ b/src/models/exercise.rs
@@ -32,6 +32,16 @@ pub struct ExerciseMetadata {
     pub name: String,
     /// Configuration for the type of sets this exercise uses
     pub set_type_config: SetTypeConfig,
+    /// Minimum number of reps for this exercise (default: 1)
+    #[serde(default = "default_min_reps")]
+    pub min_reps: i32,
+    /// Maximum number of reps for this exercise (None = unlimited)
+    #[serde(default)]
+    pub max_reps: Option<i32>,
+}
+
+fn default_min_reps() -> i32 {
+    1
 }
 
 #[cfg(test)]
@@ -47,6 +57,8 @@ mod tests {
                 min_weight: 20.0,
                 increment: 2.5,
             },
+            min_reps: 1,
+            max_reps: None,
         };
 
         assert_eq!(exercise.name, "Bench Press");
@@ -68,6 +80,8 @@ mod tests {
             id: None,
             name: "Pull-ups".to_string(),
             set_type_config: SetTypeConfig::Bodyweight,
+            min_reps: 1,
+            max_reps: None,
         };
 
         assert_eq!(exercise.name, "Pull-ups");
@@ -88,6 +102,8 @@ mod tests {
                 min_weight: 20.0,
                 increment: 2.5,
             },
+            min_reps: 1,
+            max_reps: None,
         };
 
         let json = serde_json::to_string(&original).expect("Serialization failed");
@@ -104,6 +120,8 @@ mod tests {
             id: None,
             name: "Push-ups".to_string(),
             set_type_config: SetTypeConfig::Bodyweight,
+            min_reps: 1,
+            max_reps: None,
         };
 
         let json = serde_json::to_string(&original).expect("Serialization failed");
@@ -124,11 +142,46 @@ mod tests {
                 min_weight: 20.0,
                 increment: 2.5,
             },
+            min_reps: 1,
+            max_reps: None,
         };
 
         let cloned = original.clone();
         assert_eq!(cloned.id, original.id);
         assert_eq!(cloned.name, original.name);
         assert_eq!(cloned.set_type_config, original.set_type_config);
+    }
+
+    #[test]
+    fn test_serde_round_trip_with_rep_range() {
+        let original = ExerciseMetadata {
+            id: Some(42),
+            name: "Squat".to_string(),
+            set_type_config: SetTypeConfig::Weighted {
+                min_weight: 20.0,
+                increment: 2.5,
+            },
+            min_reps: 3,
+            max_reps: Some(8),
+        };
+
+        let json = serde_json::to_string(&original).expect("Serialization failed");
+        let deserialized: ExerciseMetadata =
+            serde_json::from_str(&json).expect("Deserialization failed");
+
+        assert_eq!(deserialized.min_reps, 3);
+        assert_eq!(deserialized.max_reps, Some(8));
+        assert_eq!(deserialized, original);
+    }
+
+    #[test]
+    fn test_serde_defaults_for_missing_rep_fields() {
+        // Simulate JSON from older version without rep range fields
+        let json = r#"{"id":1,"name":"Bench","set_type_config":{"Weighted":{"min_weight":20.0,"increment":2.5}}}"#;
+        let deserialized: ExerciseMetadata =
+            serde_json::from_str(json).expect("Deserialization failed");
+
+        assert_eq!(deserialized.min_reps, 1);
+        assert_eq!(deserialized.max_reps, None);
     }
 }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -4,6 +4,7 @@
 /// sets, and workout data, along with validation logic to ensure data integrity.
 pub mod exercise;
 pub mod set;
+pub mod settings;
 pub mod validation;
 
 // Re-export commonly used types for easier access
@@ -12,6 +13,8 @@ pub mod validation;
 pub use exercise::{ExerciseMetadata, SetTypeConfig};
 #[allow(unused_imports)]
 pub use set::{CompletedSet, HistorySet, SetType};
+#[allow(unused_imports)]
+pub use settings::Settings;
 #[allow(unused_imports)]
 pub use validation::{
     ValidationError, validate_completed_set, validate_reps, validate_rpe, validate_set_number,

--- a/src/models/settings.rs
+++ b/src/models/settings.rs
@@ -1,0 +1,47 @@
+use serde::{Deserialize, Serialize};
+
+/// Global application settings, stored as a single row in the `settings` table.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct Settings {
+    /// Target RPE for auto-programming (default: 8.0)
+    pub target_rpe: f64,
+    /// Number of days of history to consider (default: 30)
+    pub history_window_days: i32,
+    /// Blend factor for today's session vs. historical data (default: 0.5)
+    pub today_blend_factor: f64,
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self {
+            target_rpe: 8.0,
+            history_window_days: 30,
+            today_blend_factor: 0.5,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_settings_default() {
+        let s = Settings::default();
+        assert_eq!(s.target_rpe, 8.0);
+        assert_eq!(s.history_window_days, 30);
+        assert_eq!(s.today_blend_factor, 0.5);
+    }
+
+    #[test]
+    fn test_settings_serde_round_trip() {
+        let original = Settings {
+            target_rpe: 7.5,
+            history_window_days: 14,
+            today_blend_factor: 0.3,
+        };
+        let json = serde_json::to_string(&original).expect("serialize");
+        let deserialized: Settings = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(deserialized, original);
+    }
+}

--- a/src/models/validation.rs
+++ b/src/models/validation.rs
@@ -386,6 +386,8 @@ mod tests {
                 min_weight: 20.0,
                 increment: 2.5,
             },
+            min_reps: 1,
+            max_reps: None,
         };
 
         let set = CompletedSet {
@@ -404,6 +406,8 @@ mod tests {
             id: None,
             name: "Pull-ups".to_string(),
             set_type_config: SetTypeConfig::Bodyweight,
+            min_reps: 1,
+            max_reps: None,
         };
 
         let set = CompletedSet {
@@ -425,6 +429,8 @@ mod tests {
                 min_weight: 20.0,
                 increment: 2.5,
             },
+            min_reps: 1,
+            max_reps: None,
         };
 
         let set = CompletedSet {
@@ -450,6 +456,8 @@ mod tests {
             id: None,
             name: "Pull-ups".to_string(),
             set_type_config: SetTypeConfig::Bodyweight,
+            min_reps: 1,
+            max_reps: None,
         };
 
         let set = CompletedSet {
@@ -469,6 +477,8 @@ mod tests {
             id: None,
             name: "Pull-ups".to_string(),
             set_type_config: SetTypeConfig::Bodyweight,
+            min_reps: 1,
+            max_reps: None,
         };
 
         let set = CompletedSet {

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -72,7 +72,7 @@ pub struct MergeConflict {
 }
 
 /// Current schema version. Bump this when the schema changes.
-const SCHEMA_VERSION: i64 = 3;
+const SCHEMA_VERSION: i64 = 4;
 
 #[derive(Clone, PartialEq)]
 pub struct Database {
@@ -163,6 +163,12 @@ impl Database {
         if current_version < 3 {
             log::debug!("[DB] Applying v3 migration: adding sync columns");
             self.apply_v3_migration().await?;
+        }
+
+        // ── v4 migration: rep ranges + settings table ───────────────────────────
+        if current_version < 4 {
+            log::debug!("[DB] Applying v4 migration: rep ranges and settings table");
+            self.apply_v4_migration().await?;
         }
 
         // Stamp the new version
@@ -267,6 +273,49 @@ impl Database {
         }
 
         log::debug!("[DB] v3 migration complete");
+        Ok(())
+    }
+
+    /// Adds `min_reps` and `max_reps` columns to the exercises table,
+    /// creates the `settings` table, and auto-seeds a default settings row.
+    async fn apply_v4_migration(&self) -> Result<(), DatabaseError> {
+        // Add rep-range columns to exercises.
+        self.add_column_if_missing(
+            "ALTER TABLE exercises ADD COLUMN min_reps INTEGER NOT NULL DEFAULT 1",
+        )
+        .await?;
+        self.add_column_if_missing("ALTER TABLE exercises ADD COLUMN max_reps INTEGER")
+            .await?;
+
+        // Create settings table.
+        self.execute_internal(
+            r#"
+            CREATE TABLE IF NOT EXISTS settings (
+                id INTEGER PRIMARY KEY CHECK (id = 1),
+                target_rpe REAL NOT NULL DEFAULT 8.0,
+                history_window_days INTEGER NOT NULL DEFAULT 30,
+                today_blend_factor REAL NOT NULL DEFAULT 0.5
+            )
+            "#,
+            &[],
+        )
+        .await?;
+
+        // Seed default settings row if absent.
+        self.seed_settings().await?;
+
+        log::debug!("[DB] v4 migration complete");
+        Ok(())
+    }
+
+    /// Inserts the default settings row if no row exists yet.
+    /// Safe to call multiple times — uses INSERT OR IGNORE.
+    async fn seed_settings(&self) -> Result<(), DatabaseError> {
+        self.execute_internal(
+            "INSERT OR IGNORE INTO settings (id, target_rpe, history_window_days, today_blend_factor) VALUES (1, 8.0, 30, 0.5)",
+            &[],
+        )
+        .await?;
         Ok(())
     }
 
@@ -588,10 +637,15 @@ impl Database {
         };
 
         let now = js_sys::Date::now();
+        let min_reps_val = JsValue::from_f64(exercise.min_reps as f64);
+        let max_reps_val = exercise
+            .max_reps
+            .map(|r| JsValue::from_f64(r as f64))
+            .unwrap_or(JsValue::NULL);
 
         let result = if let Some(id) = exercise.id {
             let sql = r#"
-                UPDATE exercises SET name = ?, is_weighted = ?, min_weight = ?, increment = ?, updated_at = ?
+                UPDATE exercises SET name = ?, is_weighted = ?, min_weight = ?, increment = ?, min_reps = ?, max_reps = ?, updated_at = ?
                 WHERE id = ?
                 RETURNING id
             "#;
@@ -604,6 +658,8 @@ impl Database {
                 increment
                     .map(|i| JsValue::from_f64(i as f64))
                     .unwrap_or(JsValue::NULL),
+                min_reps_val,
+                max_reps_val,
                 JsValue::from_f64(now),
                 JsValue::from_f64(id as f64),
             ];
@@ -611,12 +667,14 @@ impl Database {
         } else {
             let uuid = Self::generate_uuid();
             let sql = r#"
-                INSERT INTO exercises (name, is_weighted, min_weight, increment, uuid, updated_at)
-                VALUES (?, ?, ?, ?, ?, ?)
+                INSERT INTO exercises (name, is_weighted, min_weight, increment, min_reps, max_reps, uuid, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(name) DO UPDATE SET
                     is_weighted = excluded.is_weighted,
                     min_weight = excluded.min_weight,
                     increment = excluded.increment,
+                    min_reps = excluded.min_reps,
+                    max_reps = excluded.max_reps,
                     updated_at = excluded.updated_at
                 RETURNING id
             "#;
@@ -629,6 +687,8 @@ impl Database {
                 increment
                     .map(|i| JsValue::from_f64(i as f64))
                     .unwrap_or(JsValue::NULL),
+                min_reps_val,
+                max_reps_val,
                 JsValue::from_str(&uuid),
                 JsValue::from_f64(now),
             ];
@@ -656,7 +716,7 @@ impl Database {
     }
 
     pub async fn get_exercises(&self) -> Result<Vec<ExerciseMetadata>, DatabaseError> {
-        let sql = "SELECT id, name, is_weighted, min_weight, increment FROM exercises WHERE deleted_at IS NULL ORDER BY name";
+        let sql = "SELECT id, name, is_weighted, min_weight, increment, min_reps, max_reps FROM exercises WHERE deleted_at IS NULL ORDER BY name";
         let result = self.execute(sql, &[]).await?;
 
         let array = result
@@ -704,14 +764,63 @@ impl Database {
                 crate::models::SetTypeConfig::Bodyweight
             };
 
+            let min_reps = js_sys::Reflect::get(&row, &JsValue::from_str("min_reps"))?
+                .as_f64()
+                .unwrap_or(1.0) as i32;
+            let max_reps_val = js_sys::Reflect::get(&row, &JsValue::from_str("max_reps"))?;
+            let max_reps = if max_reps_val.is_null() || max_reps_val.is_undefined() {
+                None
+            } else {
+                max_reps_val.as_f64().map(|v| v as i32)
+            };
+
             exercises.push(ExerciseMetadata {
                 id,
                 name,
                 set_type_config,
+                min_reps,
+                max_reps,
             });
         }
 
         Ok(exercises)
+    }
+
+    /// Returns the current settings, seeding the default row if absent.
+    pub async fn get_settings(&self) -> Result<crate::models::Settings, DatabaseError> {
+        // Ensure the settings row exists (idempotent).
+        self.seed_settings().await?;
+
+        let sql =
+            "SELECT target_rpe, history_window_days, today_blend_factor FROM settings WHERE id = 1";
+        let result = self.execute(sql, &[]).await?;
+
+        let array = result
+            .dyn_ref::<js_sys::Array>()
+            .ok_or_else(|| DatabaseError::QueryError("Expected array result".to_string()))?;
+
+        if array.length() == 0 {
+            return Ok(crate::models::Settings::default());
+        }
+
+        let row = array.get(0);
+        let target_rpe = js_sys::Reflect::get(&row, &JsValue::from_str("target_rpe"))?
+            .as_f64()
+            .unwrap_or(8.0);
+        let history_window_days =
+            js_sys::Reflect::get(&row, &JsValue::from_str("history_window_days"))?
+                .as_f64()
+                .unwrap_or(30.0) as i32;
+        let today_blend_factor =
+            js_sys::Reflect::get(&row, &JsValue::from_str("today_blend_factor"))?
+                .as_f64()
+                .unwrap_or(0.5);
+
+        Ok(crate::models::Settings {
+            target_rpe,
+            history_window_days,
+            today_blend_factor,
+        })
     }
 
     /// Returns the most recent set for the given exercise (used for predictions).

--- a/src/state/db_tests.rs
+++ b/src/state/db_tests.rs
@@ -51,6 +51,8 @@ mod workout_state_manager_tests {
                 min_weight: 0.0,
                 increment: 5.0,
             },
+            min_reps: 1,
+            max_reps: None,
         };
         WorkoutStateManager::start_session(&state, exercise_a)
             .await
@@ -91,6 +93,8 @@ mod workout_state_manager_tests {
                 min_weight: 0.0,
                 increment: 5.0,
             },
+            min_reps: 1,
+            max_reps: None,
         };
         WorkoutStateManager::start_session(&state, exercise_b)
             .await
@@ -147,6 +151,8 @@ mod workout_state_manager_tests {
                 min_weight: 20.0,
                 increment: 2.5,
             },
+            min_reps: 1,
+            max_reps: None,
         };
         WorkoutStateManager::start_session(&state, exercise)
             .await
@@ -188,6 +194,8 @@ async fn test_database_initialization_with_existing_data() {
             min_weight: 0.0,
             increment: 5.0,
         },
+        min_reps: 1,
+        max_reps: None,
     };
     db1.save_exercise(&exercise)
         .await
@@ -221,6 +229,8 @@ async fn test_log_set_weighted() {
             min_weight: 0.0,
             increment: 5.0,
         },
+        min_reps: 1,
+        max_reps: None,
     };
     let exercise_id = db
         .save_exercise(&exercise)
@@ -249,6 +259,8 @@ async fn test_log_set_bodyweight() {
         id: None,
         name: "Pull-ups".to_string(),
         set_type_config: SetTypeConfig::Bodyweight,
+        min_reps: 1,
+        max_reps: None,
     };
     let exercise_id = db
         .save_exercise(&exercise)
@@ -284,6 +296,8 @@ async fn test_get_sets_for_exercise_pagination() {
             min_weight: 20.0,
             increment: 2.5,
         },
+        min_reps: 1,
+        max_reps: None,
     };
     let exercise_id = db
         .save_exercise(&exercise)
@@ -342,6 +356,8 @@ async fn test_get_sets_for_exercise_isolation() {
             min_weight: 0.0,
             increment: 5.0,
         },
+        min_reps: 1,
+        max_reps: None,
     };
     let id_a = db.save_exercise(&ex_a).await.expect("Save A failed");
 
@@ -352,6 +368,8 @@ async fn test_get_sets_for_exercise_isolation() {
             min_weight: 0.0,
             increment: 5.0,
         },
+        min_reps: 1,
+        max_reps: None,
     };
     let id_b = db.save_exercise(&ex_b).await.expect("Save B failed");
 
@@ -401,6 +419,8 @@ async fn test_get_sets_for_exercise_before_excludes_today() {
             min_weight: 20.0,
             increment: 2.5,
         },
+        min_reps: 1,
+        max_reps: None,
     };
     let exercise_id = db
         .save_exercise(&exercise)
@@ -459,6 +479,8 @@ async fn test_get_all_sets_paginated() {
         id: None,
         name: "Exercise One".to_string(),
         set_type_config: SetTypeConfig::Bodyweight,
+        min_reps: 1,
+        max_reps: None,
     };
     let id1 = db.save_exercise(&ex1).await.expect("Save 1 failed");
 
@@ -466,6 +488,8 @@ async fn test_get_all_sets_paginated() {
         id: None,
         name: "Exercise Two".to_string(),
         set_type_config: SetTypeConfig::Bodyweight,
+        min_reps: 1,
+        max_reps: None,
     };
     let id2 = db.save_exercise(&ex2).await.expect("Save 2 failed");
 
@@ -516,6 +540,8 @@ async fn test_update_set() {
             min_weight: 0.0,
             increment: 2.5,
         },
+        min_reps: 1,
+        max_reps: None,
     };
     let exercise_id = db
         .save_exercise(&exercise)
@@ -564,6 +590,8 @@ async fn test_update_set_recorded_at() {
             min_weight: 0.0,
             increment: 5.0,
         },
+        min_reps: 1,
+        max_reps: None,
     };
     let exercise_id = db
         .save_exercise(&exercise)
@@ -614,6 +642,8 @@ async fn test_delete_set() {
             min_weight: 0.0,
             increment: 5.0,
         },
+        min_reps: 1,
+        max_reps: None,
     };
     let exercise_id = db
         .save_exercise(&exercise)
@@ -656,6 +686,8 @@ async fn test_get_last_set_for_exercise_new_schema() {
             min_weight: 0.0,
             increment: 2.5,
         },
+        min_reps: 1,
+        max_reps: None,
     };
     let exercise_id = db
         .save_exercise(&exercise)
@@ -727,6 +759,8 @@ async fn test_save_exercise() {
             min_weight: 135.0,
             increment: 10.0,
         },
+        min_reps: 1,
+        max_reps: None,
     };
 
     let result = db.save_exercise(&exercise).await;
@@ -742,6 +776,8 @@ async fn test_save_exercise() {
             min_weight: 145.0,
             increment: 5.0,
         },
+        min_reps: 1,
+        max_reps: None,
     };
 
     let result_id_update = db.save_exercise(&updated_exercise_with_id).await;
@@ -763,6 +799,8 @@ async fn test_save_exercise() {
             min_weight: 150.0,
             increment: 10.0,
         },
+        min_reps: 1,
+        max_reps: None,
     };
 
     let result2 = db.save_exercise(&updated_exercise).await;
@@ -784,6 +822,8 @@ async fn test_export_database() {
         id: None,
         name: "Test Exercise".to_string(),
         set_type_config: SetTypeConfig::Bodyweight,
+        min_reps: 1,
+        max_reps: None,
     };
     db.save_exercise(&exercise)
         .await
@@ -826,6 +866,8 @@ async fn test_sql_injection_protection() {
             min_weight: 0.0,
             increment: 5.0,
         },
+        min_reps: 1,
+        max_reps: None,
     };
 
     let result = db.save_exercise(&exercise).await;
@@ -857,6 +899,8 @@ async fn test_export_import_round_trip() {
             min_weight: 0.0,
             increment: 5.0,
         },
+        min_reps: 1,
+        max_reps: None,
     };
     let exercise_id = db1
         .save_exercise(&exercise)
@@ -935,11 +979,15 @@ async fn test_exercises_restored_after_open_existing_database() {
             min_weight: 20.0,
             increment: 2.5,
         },
+        min_reps: 1,
+        max_reps: None,
     };
     let exercise2 = ExerciseMetadata {
         id: None,
         name: "Pull-ups".to_string(),
         set_type_config: SetTypeConfig::Bodyweight,
+        min_reps: 1,
+        max_reps: None,
     };
 
     db1.save_exercise(&exercise1)
@@ -1034,6 +1082,8 @@ async fn test_new_exercise_has_uuid() {
             min_weight: 20.0,
             increment: 2.5,
         },
+        min_reps: 1,
+        max_reps: None,
     };
     let exercise_id = db
         .save_exercise(&exercise)
@@ -1086,6 +1136,8 @@ async fn test_new_set_has_uuid_and_updated_at() {
             min_weight: 0.0,
             increment: 5.0,
         },
+        min_reps: 1,
+        max_reps: None,
     };
     let exercise_id = db
         .save_exercise(&exercise)
@@ -1143,6 +1195,8 @@ async fn test_update_set_updates_updated_at() {
             min_weight: 0.0,
             increment: 2.5,
         },
+        min_reps: 1,
+        max_reps: None,
     };
     let exercise_id = db
         .save_exercise(&exercise)
@@ -1227,6 +1281,8 @@ async fn test_delete_set_is_soft_delete() {
             min_weight: 0.0,
             increment: 5.0,
         },
+        min_reps: 1,
+        max_reps: None,
     };
     let exercise_id = db
         .save_exercise(&exercise)
@@ -1302,6 +1358,8 @@ async fn test_uuids_are_unique_across_records() {
             min_weight: 0.0,
             increment: 5.0,
         },
+        min_reps: 1,
+        max_reps: None,
     };
     let exercise_id = db
         .save_exercise(&exercise)
@@ -1704,6 +1762,8 @@ async fn test_exercises_restored_after_create_new_then_reopen() {
             min_weight: 60.0,
             increment: 5.0,
         },
+        min_reps: 1,
+        max_reps: None,
     };
     db1.save_exercise(&exercise)
         .await
@@ -1743,6 +1803,8 @@ async fn test_edit_exercise_updates_updated_at() {
             min_weight: 20.0,
             increment: 2.5,
         },
+        min_reps: 1,
+        max_reps: None,
     };
     let exercise_id = db.save_exercise(&exercise).await.expect("save failed");
 
@@ -1770,6 +1832,8 @@ async fn test_edit_exercise_updates_updated_at() {
             min_weight: 20.0,
             increment: 5.0, // changed
         },
+        min_reps: 1,
+        max_reps: None,
     };
     db.save_exercise(&updated).await.expect("update failed");
 
@@ -1817,6 +1881,8 @@ async fn test_v2_to_v3_migration_backfills_existing_rows() {
             min_weight: 60.0,
             increment: 5.0,
         },
+        min_reps: 1,
+        max_reps: None,
     };
     let ex_id = db1.save_exercise(&exercise).await.expect("save failed");
     db1.log_set(

--- a/src/state/workout_state.rs
+++ b/src/state/workout_state.rs
@@ -943,6 +943,8 @@ mod tests {
                 min_weight: 0.0,
                 increment: 5.0,
             },
+            min_reps: 1,
+            max_reps: None,
         };
 
         let predicted = WorkoutStateManager::calculate_initial_predictions(&exercise, None);
@@ -961,6 +963,8 @@ mod tests {
                 min_weight: 0.0,
                 increment: 5.0,
             },
+            min_reps: 1,
+            max_reps: None,
         };
 
         let last_set = CompletedSet {
@@ -984,6 +988,8 @@ mod tests {
             id: Some(2),
             name: "Pull-ups".to_string(),
             set_type_config: SetTypeConfig::Bodyweight,
+            min_reps: 1,
+            max_reps: None,
         };
 
         let predicted = WorkoutStateManager::calculate_initial_predictions(&exercise, None);
@@ -1002,6 +1008,8 @@ mod tests {
                 min_weight: 0.0,
                 increment: 5.0,
             },
+            min_reps: 1,
+            max_reps: None,
         };
 
         let session = WorkoutSession {

--- a/tests/steps/exercise_list_steps.rs
+++ b/tests/steps/exercise_list_steps.rs
@@ -99,6 +99,8 @@ async fn following_exercises_exist(world: &mut ExerciseListWorld, step: &cucumbe
                     id: None,
                     name: name.clone(),
                     set_type_config: config,
+                    min_reps: 1,
+                    max_reps: None,
                 });
             }
         }
@@ -153,11 +155,15 @@ async fn database_contains_standard_exercises(world: &mut ExerciseListWorld) {
             min_weight: 20.0,
             increment: 2.5,
         },
+        min_reps: 1,
+        max_reps: None,
     });
     world.exercises.push(ExerciseMetadata {
         id: None,
         name: "Push-up".to_string(),
         set_type_config: SetTypeConfig::Bodyweight,
+        min_reps: 1,
+        max_reps: None,
     });
 }
 

--- a/tests/steps/exercise_search_steps.rs
+++ b/tests/steps/exercise_search_steps.rs
@@ -87,6 +87,8 @@ async fn following_exercises_exist(
                     id: None,
                     name: name.clone(),
                     set_type_config: config,
+                    min_reps: 1,
+                    max_reps: None,
                 });
             }
         }

--- a/tests/steps/library_steps.rs
+++ b/tests/steps/library_steps.rs
@@ -101,6 +101,8 @@ async fn step_save_exercise(world: &mut LibraryWorld) {
             min_weight: 20.0,
             increment: 2.5,
         },
+        min_reps: 1,
+        max_reps: None,
     });
     world.render_component();
 }
@@ -132,6 +134,8 @@ async fn step_exercise_exists(world: &mut LibraryWorld, name: String) {
             min_weight: 20.0,
             increment: 2.5,
         },
+        min_reps: 1,
+        max_reps: None,
     });
 }
 

--- a/tests/steps/workout_steps.rs
+++ b/tests/steps/workout_steps.rs
@@ -74,6 +74,8 @@ async fn step_click_start(world: &mut WorkoutWorld) {
                 min_weight: 0.0,
                 increment: 5.0,
             },
+            min_reps: 1,
+            max_reps: None,
         },
         completed_sets: Vec::new(),
         predicted: PredictedParameters {
@@ -155,6 +157,8 @@ async fn step_active_session_with_sets(world: &mut WorkoutWorld, exercise_name: 
                 min_weight: 0.0,
                 increment: 5.0,
             },
+            min_reps: 1,
+            max_reps: None,
         },
         completed_sets: vec![simple_strength_assistant::models::CompletedSet {
             set_number: 1,
@@ -182,6 +186,8 @@ async fn step_switch_exercise(world: &mut WorkoutWorld, exercise_name: String) {
                 min_weight: 0.0,
                 increment: 2.5,
             },
+            min_reps: 1,
+            max_reps: None,
         },
         completed_sets: Vec::new(),
         predicted: PredictedParameters {


### PR DESCRIPTION
## Summary

Closes #128

Adds a v4 database migration with rep range constraints and global settings:

- `exercises` table gains `min_reps INTEGER NOT NULL DEFAULT 1` and `max_reps INTEGER NULL`
- New `settings` table (single-row, `CHECK (id = 1)`) with `target_rpe`, `history_window_days`, `today_blend_factor`
- Settings row auto-seeded on init via `INSERT OR IGNORE`
- `ExerciseMetadata` struct updated with `min_reps`/`max_reps` (serde defaults for backward compat)
- New `Settings` model struct with `Default` impl
- No UI or behavioural changes

## QA Checklist

- [ ] Fresh database init creates `exercises` table with `min_reps INTEGER NOT NULL DEFAULT 1` and `max_reps INTEGER NULL` columns
- [ ] Fresh database init creates `settings` table with columns `target_rpe REAL NOT NULL DEFAULT 8.0`, `history_window_days INTEGER NOT NULL DEFAULT 30`, `today_blend_factor REAL NOT NULL DEFAULT 0.5`
- [ ] Running migration against existing database preserves all existing exercise rows, with `min_reps=1` and `max_reps=NULL`
- [ ] Settings row is auto-seeded on first run when no settings row exists
- [ ] Opening app twice does not duplicate or overwrite existing settings row
- [ ] Rust `ExerciseMetadata` struct includes `min_reps` and `max_reps` fields and round-trips correctly through serde
- [ ] No UI changes or behavioural regressions in existing exercise/workout flows

## Test plan

- [x] All 107 unit tests pass (including new serde round-trip and defaults tests)
- [x] All 9 BDD scenarios pass (no regressions)
- [x] `cargo check`, `cargo fmt`, `cargo clippy` all pass
- [ ] WASM integration tests verify migration on fresh and existing databases (CI)
- [ ] Manual: open app fresh → verify settings row seeded, exercises have default rep ranges
- [ ] Manual: open app with existing data → verify no data loss, min_reps=1, max_reps=NULL

🤖 Generated with [Claude Code](https://claude.com/claude-code)