### PR TITLE
perf: move component-level Playwright tests to fast local suite, keep only core flow as E2E

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,21 @@ jobs:
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
+  fast-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup devenv
+        uses: ./.github/actions/setup-devenv
+
+      - name: Run fast Playwright tests (local server)
+        run: devenv shell npm run test:fast
+
   e2e-test:
     runs-on: ubuntu-latest
     needs: [build-and-deploy]
@@ -76,7 +91,7 @@ jobs:
 
   claude-review:
     runs-on: ubuntu-latest
-    needs: [lint, test, e2e-test, build-and-deploy]
+    needs: [lint, test, fast-test, e2e-test, build-and-deploy]
     permissions:
       contents: read
       pull-requests: read

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "watch:css": "postcss src/styles.css -o public/styles.css --watch",
     "test:e2e": "bddgen && playwright test",
     "test:e2e:ui": "bddgen && playwright test --ui",
-    "test:e2e:headed": "bddgen && playwright test --headed"
+    "test:e2e:headed": "bddgen && playwright test --headed",
+    "test:fast": "bddgen --config playwright.fast.config.ts && playwright test --config playwright.fast.config.ts"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.6.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,10 @@
 import { defineConfig, devices } from "@playwright/test";
 import { defineBddConfig } from "playwright-bdd";
 
+// Tag convention: every .feature file must have either @fast or @e2e.
+// @fast → runs in playwright.fast.config.ts against a local dx serve.
+// @e2e → runs here against the Vercel preview URL.
+// An untagged feature file will be silently excluded from both suites.
 const testDir = defineBddConfig({
   features: "tests/e2e/features/**/*.feature",
   steps: "tests/e2e/steps/**/*.ts",

--- a/playwright.fast.config.ts
+++ b/playwright.fast.config.ts
@@ -4,10 +4,8 @@ import { defineBddConfig } from "playwright-bdd";
 const testDir = defineBddConfig({
   features: "tests/e2e/features/**/*.feature",
   steps: "tests/e2e/steps/**/*.ts",
-  tags: "@e2e",
+  tags: "@fast",
 });
-
-const baseURL = process.env.PLAYWRIGHT_BASE_URL || "http://localhost:3000";
 
 export default defineConfig({
   testDir,
@@ -15,37 +13,28 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  workers: process.env.CI ? 4 : undefined,
   reporter: process.env.CI ? [["list"], ["html", { open: "never" }]] : "html",
-  webServer: process.env.PLAYWRIGHT_BASE_URL
-    ? undefined
-    : {
-        command: "dx serve --port 3000",
-        url: "http://localhost:3000",
-        reuseExistingServer: true,
-        timeout: 300000,
-      },
+  webServer: {
+    command: "dx serve --port 3000",
+    url: "http://localhost:3000",
+    reuseExistingServer: true,
+    timeout: 300000,
+  },
   use: {
-    baseURL,
+    baseURL: "http://localhost:3000",
     trace: "on-first-retry",
-    serviceWorkers: process.env.PLAYWRIGHT_BASE_URL ? "block" : "allow",
-    extraHTTPHeaders: process.env.VERCEL_AUTOMATION_BYPASS_SECRET
-      ? {
-          "x-vercel-protection-bypass":
-            process.env.VERCEL_AUTOMATION_BYPASS_SECRET,
-        }
-      : {},
+    serviceWorkers: "allow",
   },
   projects: [
     {
       name: "chromium",
       use: {
         ...devices["Desktop Chrome"],
-        // Use Nix-provided Chromium for NixOS compatibility
         launchOptions: process.env.CHROMIUM_EXECUTABLE_PATH
           ? {
               executablePath: process.env.CHROMIUM_EXECUTABLE_PATH,
-              headless: true, // Ensures HeadlessChrome in user agent for E2E test mode detection
+              headless: true,
             }
           : {
               headless: true,

--- a/playwright.fast.config.ts
+++ b/playwright.fast.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig, devices } from "@playwright/test";
 import { defineBddConfig } from "playwright-bdd";
 
+// Tag convention: every .feature file must have either @fast or @e2e.
+// @fast → runs here against a local dx serve. @e2e → runs in playwright.config.ts against Vercel.
+// An untagged feature file will be silently excluded from both suites.
 const testDir = defineBddConfig({
   features: "tests/e2e/features/**/*.feature",
   steps: "tests/e2e/steps/**/*.ts",
@@ -12,14 +15,14 @@ export default defineConfig({
   timeout: process.env.CI ? 60000 : 30000,
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 2 : 0,
+  retries: 0,
   workers: process.env.CI ? 4 : undefined,
   reporter: process.env.CI ? [["list"], ["html", { open: "never" }]] : "html",
   webServer: {
     command: "dx serve --port 3000",
     url: "http://localhost:3000",
     reuseExistingServer: true,
-    timeout: 300000,
+    timeout: 120000,
   },
   use: {
     baseURL: "http://localhost:3000",
@@ -31,14 +34,12 @@ export default defineConfig({
       name: "chromium",
       use: {
         ...devices["Desktop Chrome"],
-        launchOptions: process.env.CHROMIUM_EXECUTABLE_PATH
-          ? {
-              executablePath: process.env.CHROMIUM_EXECUTABLE_PATH,
-              headless: true,
-            }
-          : {
-              headless: true,
-            },
+        launchOptions: {
+          headless: true,
+          ...(process.env.CHROMIUM_EXECUTABLE_PATH && {
+            executablePath: process.env.CHROMIUM_EXECUTABLE_PATH,
+          }),
+        },
       },
     },
   ],

--- a/playwright.fast.config.ts
+++ b/playwright.fast.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
   timeout: process.env.CI ? 60000 : 30000,
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
-  retries: 0,
+  retries: process.env.CI ? 1 : 0,
   workers: process.env.CI ? 4 : undefined,
   reporter: process.env.CI ? [["list"], ["html", { open: "never" }]] : "html",
   webServer: {

--- a/tests/e2e/features/core_flow.feature
+++ b/tests/e2e/features/core_flow.feature
@@ -1,0 +1,18 @@
+@e2e
+Feature: Core user journey
+  As a user
+  I want to open the app, create a database, log a set, and view it in history
+  So that I know the full end-to-end flow works against the deployed environment
+
+  Scenario: Open app, create DB, log a set, view in history, see sync indicator
+    Given I have a fresh context and clear storage
+    And I create a new database
+    And I start a test session with "Bench Press"
+    When I log a set in the current session
+    Then the in-progress sets section should show "Today's Sets (1 set)"
+    When I click the history icon in the session header
+    Then I should be on the history page
+    And the history feed should contain at least 1 set row
+    When I click the back button on the history page
+    And I click on the "Workout" tab
+    Then the sync status indicator should be visible

--- a/tests/e2e/features/data_management.feature
+++ b/tests/e2e/features/data_management.feature
@@ -1,3 +1,4 @@
+@fast
 Feature: Data export and import
   As a user
   I want to export and import my workout database

--- a/tests/e2e/features/edit_delete_set.feature
+++ b/tests/e2e/features/edit_delete_set.feature
@@ -1,3 +1,4 @@
+@fast
 Feature: Edit/Delete Set Modal
   As a user
   I want to edit or delete logged sets in the history view

--- a/tests/e2e/features/exercise_detail.feature
+++ b/tests/e2e/features/exercise_detail.feature
@@ -3,7 +3,7 @@ Feature: Exercise Detail View
   I want to see the details and history of a specific exercise
   So that I can review my progress and start a session
 
-  @e2e
+  @fast
   Scenario: Open detail view from library and start a session
     Given I have a fresh context and clear storage
     And I create a new database
@@ -17,7 +17,7 @@ Feature: Exercise Detail View
     Then the user should be on the Workout tab
     And a session for "Bench Press" should be active
 
-  @e2e
+  @fast
   Scenario: Edit exercise from detail view
     Given I have a fresh context and clear storage
     And I create a new database
@@ -30,7 +30,7 @@ Feature: Exercise Detail View
     And the user saves the exercise
     Then the user should see "HEAVY SQUAT" in the header
 
-  @e2e
+  @fast
   Scenario: Back button returns to library
     Given I have a fresh context and clear storage
     And I create a new database

--- a/tests/e2e/features/exercise_list.feature
+++ b/tests/e2e/features/exercise_list.feature
@@ -3,7 +3,7 @@ Feature: Exercise List Display
   I want to see a list of my exercises
   So that I can browse and select exercises for my workout
 
-  @e2e
+  @fast
   Scenario: End-to-end user flow for viewing the exercise list
     Given I have a fresh context and clear storage
     And I create a new database

--- a/tests/e2e/features/exercise_search.feature
+++ b/tests/e2e/features/exercise_search.feature
@@ -3,7 +3,7 @@ Feature: Exercise Search and Filtering
   I want to search and filter my exercise list
   So that I can quickly find the exercise I want to perform
 
-  @e2e
+  @fast
   Scenario: End-to-end user flow for searching exercises
     Given I have a fresh context and clear storage
     And I create a new database

--- a/tests/e2e/features/navigation.feature
+++ b/tests/e2e/features/navigation.feature
@@ -1,3 +1,4 @@
+@fast
 Feature: App Navigation
   As a user
   I want the app to remember my position in each tab

--- a/tests/e2e/features/previous_sessions.feature
+++ b/tests/e2e/features/previous_sessions.feature
@@ -1,3 +1,4 @@
+@fast
 Feature: Collapsible Previous Sessions in active workout
   As a user logging a workout
   I want to see my past sets for the current exercise

--- a/tests/e2e/features/rpe_slider.feature
+++ b/tests/e2e/features/rpe_slider.feature
@@ -1,3 +1,4 @@
+@fast
 Feature: RPESlider Component E2E
 
   Background:

--- a/tests/e2e/features/shell_layout.feature
+++ b/tests/e2e/features/shell_layout.feature
@@ -1,3 +1,4 @@
+@fast
 Feature: Shell layout — fixed navigation bar
   As a user
   I want the bottom navigation bar to always be visible

--- a/tests/e2e/features/step_controls.feature
+++ b/tests/e2e/features/step_controls.feature
@@ -1,3 +1,4 @@
+@fast
 Feature: StepControls Component E2E
 
   Background:

--- a/tests/e2e/features/sync_status.feature
+++ b/tests/e2e/features/sync_status.feature
@@ -1,3 +1,4 @@
+@fast
 Feature: Sync Status Indicator
   As a user
   I want to see the current sync state at a glance

--- a/tests/e2e/features/tapemeasure.feature
+++ b/tests/e2e/features/tapemeasure.feature
@@ -1,3 +1,4 @@
+@fast
 Feature: TapeMeasure Component E2E
 
   Background:

--- a/tests/e2e/features/todays_sets.feature
+++ b/tests/e2e/features/todays_sets.feature
@@ -1,3 +1,4 @@
+@fast
 Feature: Today's Sets section label in active session
   As a user logging a workout
   I want the in-progress sets section to be clearly labelled "Today's Sets"

--- a/tests/e2e/features/workout_history.feature
+++ b/tests/e2e/features/workout_history.feature
@@ -1,3 +1,4 @@
+@fast
 Feature: Full workout history view
   As a user
   I want to view my complete workout history


### PR DESCRIPTION
## Summary

- Tagged 14 component-level feature files with `@fast` to run against a local `dx serve` with parallel workers (4 in CI)
- Created `playwright.fast.config.ts` filtering for `@fast` tag, local base URL, no Vercel dependency
- Updated `playwright.config.ts` to filter for `@e2e` tag only
- Created `core_flow.feature` (`@e2e`) covering the end-to-end user journey: open app, create DB, log set, view in history, verify sync indicator
- Only 1 scenario runs against Vercel (core_flow) — down from 15
- Added `test:fast` npm script

Closes #138

## CI workflow change (requires manual application)

The OAuth token lacks `workflow` scope, so `.github/workflows/ci.yml` could not be pushed. The following change needs to be applied manually:

Add a `fast-test` job (no `needs` dependency — runs in parallel with `build-and-deploy`):

```yaml
  fast-test:
    runs-on: ubuntu-latest

    steps:
      - name: Checkout code
        uses: actions/checkout@v4
        with:
          fetch-depth: 0

      - name: Setup devenv
        uses: ./.github/actions/setup-devenv

      - name: Run fast Playwright tests (local server)
        run: devenv shell npm run test:fast
```

And update `claude-review` needs to include `fast-test`:

```yaml
    needs: [lint, test, fast-test, e2e-test, build-and-deploy]
```

## QA Checklist (from ralph-assess)

- [ ] CI pipeline has a `fast-test` job that runs without waiting for `build-and-deploy` to complete
- [ ] `fast-test` job completes in under 10 minutes on a typical PR
- [ ] `e2e-test` job runs 3 or fewer scenarios against the Vercel preview URL
- [ ] All 13 component-level feature files (rpe_slider, step_controls, exercise_list, exercise_detail, exercise_search, navigation, shell_layout, tapemeasure, todays_sets, previous_sessions, workout_history, edit_delete_set, data_management) pass in the fast suite against a local dev server
- [ ] A core user-journey scenario (open app, create DB, log a set, view in history) exists and passes against the Vercel preview URL
- [ ] No existing test scenarios are deleted — all are preserved and reachable via either the fast or e2e suite
- [ ] Total CI wall-clock time for a typical PR is under 30 minutes

## Test plan

- [ ] Verify `bddgen --config playwright.fast.config.ts` generates specs for all 14 `@fast` features
- [ ] Verify `bddgen` (default config) generates specs only for `core_flow.feature`
- [ ] Run `npm run test:fast` locally and confirm all 14 feature files pass
- [ ] Run `npm run test:e2e` locally and confirm core_flow passes
- [ ] Apply CI workflow change and verify `fast-test` job runs in parallel with `build-and-deploy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)