### PR TITLE
fix(#143): break infinite sync-effect loop that crashes production

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -3301,9 +3301,6 @@ details.collapse summary::-webkit-details-marker {
 .mt-8 {
   margin-top: 2rem;
 }
-.block {
-  display: block;
-}
 .inline {
   display: inline;
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -467,26 +467,25 @@ pub fn App() -> Element {
         }
     });
 
-    // Trigger background sync once the database transitions to Ready.
+    // Trigger background sync exactly once when the database transitions to Ready.
     // Sync is non-blocking: the app is fully usable while sync runs.
     // Sync short-circuits if no credentials are configured (see SyncCredentials::load),
     // so it is safe to run even when sync is not set up or in E2E test environments.
-    // A `sync_in_progress` guard prevents duplicate sync cycles if the
-    // effect re-fires (e.g. due to re-renders or state transitions).
+    // A one-shot `sync_attempted` flag ensures the sync fires at most once per
+    // app load, preventing the infinite re-trigger loop that occurs when a
+    // completion callback resets a guard signal the effect subscribes to.
     //
     // The `#[cfg(not(test))]` guard is needed because `trigger_background_sync`
     // depends on the real HTTP client module which is excluded from test builds.
     #[cfg(not(test))]
     {
-        let mut sync_in_progress = use_signal(|| false);
+        let mut sync_attempted = use_signal(|| false);
         use_effect(move || {
             if workout_state.initialization_state() == InitializationState::Ready
-                && !sync_in_progress()
+                && !sync_attempted()
             {
                 // Skip sync in test mode — the test harness sets __TEST_MODE__
-                // and there is no sync server to talk to. Running sync here would
-                // block the main thread waiting for a network response that never
-                // comes, freezing the page for Playwright.
+                // and there is no sync server to talk to.
                 let is_fallback = workout_state
                     .file_manager()
                     .map(|fm| fm.is_using_fallback())
@@ -494,11 +493,11 @@ pub fn App() -> Element {
                 if is_fallback {
                     return;
                 }
-                sync_in_progress.set(true);
+                sync_attempted.set(true);
                 spawn(async move {
                     log::debug!("[Sync] App ready — starting background sync");
                     WorkoutStateManager::trigger_background_sync(&workout_state).await;
-                    sync_in_progress.set(false);
+                    log::debug!("[Sync] Background sync complete");
                 });
             }
         });

--- a/src/app.rs
+++ b/src/app.rs
@@ -485,7 +485,9 @@ pub fn App() -> Element {
                 && !sync_attempted()
             {
                 // Skip sync in test mode — the test harness sets __TEST_MODE__
-                // and there is no sync server to talk to.
+                // and there is no sync server to talk to. Running sync here would
+                // attempt a network request that never completes, freezing the
+                // page for Playwright.
                 let is_fallback = workout_state
                     .file_manager()
                     .map(|fm| fm.is_using_fallback())

--- a/tests/e2e/features/production_boot.feature
+++ b/tests/e2e/features/production_boot.feature
@@ -1,0 +1,15 @@
+@e2e
+Feature: Production boot without test mode
+  As a user on the production site
+  I want the app to load without crashing after creating a database
+  So I can use the workout assistant
+
+  Scenario: App reaches workout view after creating a new database
+    Given I open the app without test mode and clear storage
+    When I click "Create New Database"
+    Then the app should reach the workout view within 10 seconds
+
+  Scenario: Sync fires at most once per app load
+    Given I open the app without test mode and clear storage
+    When I click "Create New Database"
+    Then the sync should start at most once

--- a/tests/e2e/steps/production_boot.steps.ts
+++ b/tests/e2e/steps/production_boot.steps.ts
@@ -1,0 +1,74 @@
+import { createBdd } from "playwright-bdd";
+import { test as base } from "playwright-bdd";
+import { expect } from "@playwright/test";
+
+// This test intentionally does NOT inject __TEST_MODE__ = true,
+// so it exercises the real production code path including sync.
+const test = base.extend<{}>({
+  page: async ({ page }, use) => {
+    // No __TEST_MODE__ injection — this is the production path
+    await use(page);
+  },
+});
+
+const { Given, When, Then } = createBdd(test);
+
+Given(
+  "I open the app without test mode and clear storage",
+  async ({ page, context }) => {
+    page.on("console", (msg) => console.log("BROWSER:", msg.text()));
+    page.on("pageerror", (error) =>
+      console.error("BROWSER ERROR:", error),
+    );
+
+    await context.clearCookies();
+    await page.goto("/");
+    await page.evaluate(() => localStorage.clear());
+    await page.waitForLoadState("networkidle");
+  },
+);
+
+When("I click {string}", async ({ page }, buttonText: string) => {
+  await page.click(`button:has-text("${buttonText}")`);
+});
+
+Then(
+  "the app should reach the workout view within 10 seconds",
+  async ({ page }) => {
+    // The body gets data-hydrated="true" once past loading state.
+    // If the infinite loop bug is present, the page will freeze/crash
+    // and this selector will time out.
+    await page.waitForSelector('body[data-hydrated="true"]', {
+      timeout: 10000,
+    });
+
+    // Verify the page is actually responsive — the workout tab should be visible
+    await expect(page.locator('button:has-text("Workout")')).toBeVisible({
+      timeout: 5000,
+    });
+  },
+);
+
+Then("the sync should start at most once", async ({ page }) => {
+  // Wait for hydration first
+  await page.waitForSelector('body[data-hydrated="true"]', {
+    timeout: 10000,
+  });
+
+  // Give sync time to complete and any potential re-triggers to fire
+  await page.waitForTimeout(2000);
+
+  // Collect console logs that match the sync start message.
+  // The app logs "[Sync] App ready — starting background sync" each time
+  // the sync effect fires. If the loop bug is present, we'd see dozens.
+  const syncLogs = await page.evaluate(() => {
+    return (window as any).__syncStartCount ?? 0;
+  });
+
+  // We injected a counter via addInitScript — but since we're NOT in test
+  // mode here, we instead check console messages collected during the test.
+  // The console listener was set up in the Given step.
+  // For robustness, we'll just verify the page is still responsive
+  // (not crashed) after 2 seconds — a crashed page would have timed out above.
+  await expect(page.locator('button:has-text("Workout")')).toBeVisible();
+});

--- a/tests/e2e/steps/production_boot.steps.ts
+++ b/tests/e2e/steps/production_boot.steps.ts
@@ -36,7 +36,7 @@ Then(
     });
 
     // Verify the page is actually responsive — the workout tab should be visible
-    await expect(page.locator('button:has-text("Workout")')).toBeVisible({
+    await expect(page.getByTestId("tab-workout")).toBeVisible({
       timeout: 5000,
     });
   },
@@ -63,5 +63,5 @@ Then("the sync should start at most once", async ({ page }) => {
   // The console listener was set up in the Given step.
   // For robustness, we'll just verify the page is still responsive
   // (not crashed) after 2 seconds — a crashed page would have timed out above.
-  await expect(page.locator('button:has-text("Workout")')).toBeVisible();
+  await expect(page.getByTestId("tab-workout")).toBeVisible();
 });

--- a/tests/e2e/steps/production_boot.steps.ts
+++ b/tests/e2e/steps/production_boot.steps.ts
@@ -1,17 +1,4 @@
-import { createBdd } from "playwright-bdd";
-import { test as base } from "playwright-bdd";
-import { expect } from "@playwright/test";
-
-// This test intentionally does NOT inject __TEST_MODE__ = true,
-// so it exercises the real production code path including sync.
-const test = base.extend<{}>({
-  page: async ({ page }, use) => {
-    // No __TEST_MODE__ injection — this is the production path
-    await use(page);
-  },
-});
-
-const { Given, When, Then } = createBdd(test);
+import { Given, When, Then, expect } from "./fixtures";
 
 Given(
   "I open the app without test mode and clear storage",
@@ -20,6 +7,12 @@ Given(
     page.on("pageerror", (error) =>
       console.error("BROWSER ERROR:", error),
     );
+
+    // Override the __TEST_MODE__ flag set by the fixtures so this test
+    // exercises the real production code path including sync.
+    await page.addInitScript(() => {
+      delete (window as unknown as Record<string, unknown>).__TEST_MODE__;
+    });
 
     await context.clearCookies();
     await page.goto("/");

--- a/tests/e2e/steps/production_boot.steps.ts
+++ b/tests/e2e/steps/production_boot.steps.ts
@@ -4,9 +4,7 @@ Given(
   "I open the app without test mode and clear storage",
   async ({ page, context }) => {
     page.on("console", (msg) => console.log("BROWSER:", msg.text()));
-    page.on("pageerror", (error) =>
-      console.error("BROWSER ERROR:", error),
-    );
+    page.on("pageerror", (error) => console.error("BROWSER ERROR:", error));
 
     // Override the __TEST_MODE__ flag set by the fixtures so this test
     // exercises the real production code path including sync.

--- a/tests/e2e/steps/production_boot.steps.ts
+++ b/tests/e2e/steps/production_boot.steps.ts
@@ -8,8 +8,22 @@ Given(
 
     // Override the __TEST_MODE__ flag set by the fixtures so this test
     // exercises the real production code path including sync.
+    // Also inject a counter that patches console.debug to count how many
+    // times the sync effect fires — used by the "at most once" assertion.
     await page.addInitScript(() => {
       delete (window as unknown as Record<string, unknown>).__TEST_MODE__;
+
+      (window as any).__syncStartCount = 0;
+      const origDebug = console.debug.bind(console);
+      console.debug = (...args: unknown[]) => {
+        if (
+          typeof args[0] === "string" &&
+          args[0].includes("[Sync] App ready")
+        ) {
+          (window as any).__syncStartCount++;
+        }
+        origDebug(...args);
+      };
     });
 
     await context.clearCookies();
@@ -46,20 +60,25 @@ Then("the sync should start at most once", async ({ page }) => {
     timeout: 10000,
   });
 
-  // Give sync time to complete and any potential re-triggers to fire
-  await page.waitForTimeout(2000);
+  // Wait for the sync-complete log message rather than an arbitrary timeout.
+  // If sync doesn't run (e.g. no credentials), the 5s timeout is a safe upper bound.
+  try {
+    await page.waitForEvent("console", {
+      predicate: (msg) =>
+        msg.text().includes("[Sync] Background sync complete"),
+      timeout: 5000,
+    });
+  } catch {
+    // Sync may not fire at all (no credentials configured) — that's fine.
+  }
 
-  // Collect console logs that match the sync start message.
-  // The app logs "[Sync] App ready — starting background sync" each time
-  // the sync effect fires. If the loop bug is present, we'd see dozens.
-  const syncLogs = await page.evaluate(() => {
-    return (window as any).__syncStartCount ?? 0;
-  });
+  // Read the counter injected by addInitScript that patches console.debug.
+  // Each "[Sync] App ready" log increments __syncStartCount.
+  const count = await page.evaluate(
+    () => (window as any).__syncStartCount ?? 0,
+  );
+  expect(count).toBeLessThanOrEqual(1);
 
-  // We injected a counter via addInitScript — but since we're NOT in test
-  // mode here, we instead check console messages collected during the test.
-  // The console listener was set up in the Given step.
-  // For robustness, we'll just verify the page is still responsive
-  // (not crashed) after 2 seconds — a crashed page would have timed out above.
+  // Also verify the page is still responsive
   await expect(page.getByTestId("tab-workout")).toBeVisible();
 });


### PR DESCRIPTION
## Summary

- **Root cause:** The sync `use_effect` in `App` subscribed to `sync_in_progress` by reading it, then the spawned async task set it back to `false` on completion — re-triggering the effect and creating a tight infinite loop that exhausted WASM memory within ~250ms.
- **Fix:** Replace the `sync_in_progress` toggle with a one-shot `sync_attempted` flag that is only ever set to `true` and never cleared. The effect now fires exactly once per `Ready` transition.
- **Tests:** Added `production_boot.feature` E2E test that runs without `__TEST_MODE__`, verifying the app reaches the workout view after "Create New Database" and that sync fires at most once.

Closes #143

## Test plan

- [ ] New `production_boot.feature` E2E test passes (app reaches workout view without `__TEST_MODE__`)
- [ ] Existing E2E tests (with `__TEST_MODE__`) still pass
- [ ] Manual verification: open production URL, click "Create New Database", confirm page does not freeze
- [ ] Check browser console for duplicate `[Sync] App ready` log entries (should appear at most once)

🤖 Generated with [Claude Code](https://claude.com/claude-code)