### PR TITLE
feat: add history queries for e1RM calculation

### DIFF
--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -883,6 +883,142 @@ impl Database {
         }))
     }
 
+    /// Returns the set with the highest computed e1RM for the given exercise
+    /// within the history window `[since_ms, now)`, **excluding** sets whose
+    /// `recorded_at` falls in `[exclude_start_ms, exclude_end_ms)`.
+    ///
+    /// e1RM comparison is performed in Rust using `domain::e1rm::e1rm()` so
+    /// that the ranking logic stays in one place.
+    ///
+    /// Bodyweight sets are skipped because e1RM is undefined without a weight.
+    pub async fn get_best_set_for_exercise(
+        &self,
+        exercise_id: i64,
+        since_ms: f64,
+        exclude_start_ms: f64,
+        exclude_end_ms: f64,
+    ) -> Result<Option<CompletedSet>, DatabaseError> {
+        let sql = r#"
+            SELECT set_number, reps, rpe, weight, is_bodyweight
+            FROM completed_sets
+            WHERE exercise_id = ?
+              AND deleted_at IS NULL
+              AND recorded_at >= ?
+              AND (recorded_at < ? OR recorded_at >= ?)
+              AND is_bodyweight = 0
+        "#;
+
+        let params = vec![
+            JsValue::from_f64(exercise_id as f64),
+            JsValue::from_f64(since_ms),
+            JsValue::from_f64(exclude_start_ms),
+            JsValue::from_f64(exclude_end_ms),
+        ];
+
+        let result = self.execute(sql, &params).await?;
+
+        let array = result
+            .dyn_ref::<js_sys::Array>()
+            .ok_or_else(|| DatabaseError::QueryError("Expected array result".to_string()))?;
+
+        let mut best: Option<(CompletedSet, f64)> = None;
+
+        for i in 0..array.length() {
+            let row = array.get(i);
+            let completed = self.parse_completed_set_row(&row)?;
+
+            if let SetType::Weighted { weight } = completed.set_type {
+                let estimate =
+                    crate::domain::e1rm::e1rm(weight as f64, completed.reps, completed.rpe as f64);
+                match &best {
+                    Some((_, best_e1rm)) if estimate <= *best_e1rm => {}
+                    _ => best = Some((completed, estimate)),
+                }
+            }
+        }
+
+        Ok(best.map(|(set, _)| set))
+    }
+
+    /// Returns the most recently logged set for the given exercise on "today",
+    /// defined as the half-open interval `[today_start_ms, today_end_ms)`.
+    ///
+    /// Returns `None` when no sets were logged today for this exercise.
+    pub async fn get_latest_set_today(
+        &self,
+        exercise_id: i64,
+        today_start_ms: f64,
+        today_end_ms: f64,
+    ) -> Result<Option<CompletedSet>, DatabaseError> {
+        let sql = r#"
+            SELECT set_number, reps, rpe, weight, is_bodyweight
+            FROM completed_sets
+            WHERE exercise_id = ?
+              AND deleted_at IS NULL
+              AND recorded_at >= ?
+              AND recorded_at < ?
+            ORDER BY recorded_at DESC, id DESC
+            LIMIT 1
+        "#;
+
+        let params = vec![
+            JsValue::from_f64(exercise_id as f64),
+            JsValue::from_f64(today_start_ms),
+            JsValue::from_f64(today_end_ms),
+        ];
+
+        let result = self.execute(sql, &params).await?;
+
+        let array = result
+            .dyn_ref::<js_sys::Array>()
+            .ok_or_else(|| DatabaseError::QueryError("Expected array result".to_string()))?;
+
+        if array.length() == 0 {
+            return Ok(None);
+        }
+
+        let row = array.get(0);
+        Ok(Some(self.parse_completed_set_row(&row)?))
+    }
+
+    /// Parses a single row (with set_number, reps, rpe, weight, is_bodyweight)
+    /// into a `CompletedSet`.
+    fn parse_completed_set_row(&self, row: &JsValue) -> Result<CompletedSet, DatabaseError> {
+        let set_number = js_sys::Reflect::get(row, &JsValue::from_str("set_number"))?
+            .as_f64()
+            .ok_or_else(|| DatabaseError::QueryError("Failed to get set_number".to_string()))?
+            as u32;
+
+        let reps = js_sys::Reflect::get(row, &JsValue::from_str("reps"))?
+            .as_f64()
+            .ok_or_else(|| DatabaseError::QueryError("Failed to get reps".to_string()))?
+            as u32;
+
+        let rpe = js_sys::Reflect::get(row, &JsValue::from_str("rpe"))?
+            .as_f64()
+            .ok_or_else(|| DatabaseError::QueryError("Failed to get rpe".to_string()))?
+            as f32;
+
+        let is_bodyweight = self.parse_bool_field(row, "is_bodyweight")?;
+
+        let set_type = if is_bodyweight {
+            SetType::Bodyweight
+        } else {
+            let weight = js_sys::Reflect::get(row, &JsValue::from_str("weight"))?
+                .as_f64()
+                .ok_or_else(|| DatabaseError::QueryError("Failed to get weight".to_string()))?
+                as f32;
+            SetType::Weighted { weight }
+        };
+
+        Ok(CompletedSet {
+            set_number,
+            reps,
+            rpe,
+            set_type,
+        })
+    }
+
     /// Execute a raw SQL statement with string parameters.
     ///
     /// Each parameter value is bound as a JsValue string. For NULL handling,

--- a/src/state/db_tests.rs
+++ b/src/state/db_tests.rs
@@ -1984,7 +1984,10 @@ async fn setup_exercise_for_history() -> (Database, i64) {
         min_reps: 1,
         max_reps: None,
     };
-    let id = db.save_exercise(&exercise).await.expect("save_exercise failed");
+    let id = db
+        .save_exercise(&exercise)
+        .await
+        .expect("save_exercise failed");
     (db, id)
 }
 
@@ -2008,7 +2011,9 @@ async fn test_best_set_returns_highest_e1rm() {
         rpe: 8.0,
         set_type: SetType::Weighted { weight: 100.0 },
     };
-    db.log_set_at(eid, &set_a, day(3) + 1000.0).await.expect("log A");
+    db.log_set_at(eid, &set_a, day(3) + 1000.0)
+        .await
+        .expect("log A");
 
     // Set B: 120kg x 3 @ RPE 9 on day 5 — higher e1RM
     let set_b = CompletedSet {
@@ -2017,7 +2022,9 @@ async fn test_best_set_returns_highest_e1rm() {
         rpe: 9.0,
         set_type: SetType::Weighted { weight: 120.0 },
     };
-    db.log_set_at(eid, &set_b, day(5) + 1000.0).await.expect("log B");
+    db.log_set_at(eid, &set_b, day(5) + 1000.0)
+        .await
+        .expect("log B");
 
     // Set C: 80kg x 8 @ RPE 7 on day 7 — lower e1RM
     let set_c = CompletedSet {
@@ -2026,7 +2033,9 @@ async fn test_best_set_returns_highest_e1rm() {
         rpe: 7.0,
         set_type: SetType::Weighted { weight: 80.0 },
     };
-    db.log_set_at(eid, &set_c, day(7) + 1000.0).await.expect("log C");
+    db.log_set_at(eid, &set_c, day(7) + 1000.0)
+        .await
+        .expect("log C");
 
     let best = db
         .get_best_set_for_exercise(eid, day(0), today_start, today_end)

--- a/src/state/db_tests.rs
+++ b/src/state/db_tests.rs
@@ -2060,7 +2060,9 @@ async fn test_best_set_excludes_today() {
         rpe: 10.0,
         set_type: SetType::Weighted { weight: 200.0 },
     };
-    db.log_set_at(eid, &set_today, today_start + 5000.0).await.expect("log today");
+    db.log_set_at(eid, &set_today, today_start + 5000.0)
+        .await
+        .expect("log today");
 
     // Weaker set in history — should be returned
     let set_history = CompletedSet {
@@ -2069,7 +2071,9 @@ async fn test_best_set_excludes_today() {
         rpe: 8.0,
         set_type: SetType::Weighted { weight: 100.0 },
     };
-    db.log_set_at(eid, &set_history, day(5) + 1000.0).await.expect("log history");
+    db.log_set_at(eid, &set_history, day(5) + 1000.0)
+        .await
+        .expect("log history");
 
     let best = db
         .get_best_set_for_exercise(eid, day(0), today_start, today_end)
@@ -2117,7 +2121,9 @@ async fn test_best_set_all_sets_today() {
         rpe: 8.0,
         set_type: SetType::Weighted { weight: 100.0 },
     };
-    db.log_set_at(eid, &set, today_start + 1000.0).await.expect("log");
+    db.log_set_at(eid, &set, today_start + 1000.0)
+        .await
+        .expect("log");
 
     let best = db
         .get_best_set_for_exercise(eid, day(0), today_start, today_end)
@@ -2141,7 +2147,9 @@ async fn test_best_set_respects_since_date() {
         rpe: 10.0,
         set_type: SetType::Weighted { weight: 200.0 },
     };
-    db.log_set_at(eid, &old_set, day(2) + 1000.0).await.expect("log old");
+    db.log_set_at(eid, &old_set, day(2) + 1000.0)
+        .await
+        .expect("log old");
 
     // Weaker set on day 8 (inside window)
     let recent_set = CompletedSet {
@@ -2150,7 +2158,9 @@ async fn test_best_set_respects_since_date() {
         rpe: 8.0,
         set_type: SetType::Weighted { weight: 100.0 },
     };
-    db.log_set_at(eid, &recent_set, day(8) + 1000.0).await.expect("log recent");
+    db.log_set_at(eid, &recent_set, day(8) + 1000.0)
+        .await
+        .expect("log recent");
 
     // Window starts at day 5, so old_set (day 2) is excluded
     let best = db
@@ -2179,7 +2189,9 @@ async fn test_latest_set_today_returns_most_recent() {
         rpe: 7.0,
         set_type: SetType::Weighted { weight: 80.0 },
     };
-    db.log_set_at(eid, &set_early, today_start + 1000.0).await.expect("log early");
+    db.log_set_at(eid, &set_early, today_start + 1000.0)
+        .await
+        .expect("log early");
 
     // Later set today
     let set_late = CompletedSet {
@@ -2188,7 +2200,9 @@ async fn test_latest_set_today_returns_most_recent() {
         rpe: 9.0,
         set_type: SetType::Weighted { weight: 100.0 },
     };
-    db.log_set_at(eid, &set_late, today_start + 5000.0).await.expect("log late");
+    db.log_set_at(eid, &set_late, today_start + 5000.0)
+        .await
+        .expect("log late");
 
     let latest = db
         .get_latest_set_today(eid, today_start, today_end)
@@ -2232,7 +2246,9 @@ async fn test_latest_set_today_ignores_other_days() {
         rpe: 8.0,
         set_type: SetType::Weighted { weight: 100.0 },
     };
-    db.log_set_at(eid, &yesterday_set, day(9) + 5000.0).await.expect("log yesterday");
+    db.log_set_at(eid, &yesterday_set, day(9) + 5000.0)
+        .await
+        .expect("log yesterday");
 
     let latest = db
         .get_latest_set_today(eid, today_start, today_end)

--- a/src/state/db_tests.rs
+++ b/src/state/db_tests.rs
@@ -1966,3 +1966,278 @@ async fn test_v2_to_v3_migration_backfills_existing_rows() {
         );
     }
 }
+
+// ── History query tests for e1RM calculation (#131) ─────────────────────────
+
+/// Helper: creates a fresh DB with a weighted exercise and returns (db, exercise_id).
+async fn setup_exercise_for_history() -> (Database, i64) {
+    let mut db = Database::new();
+    db.init(None).await.expect("DB init failed");
+
+    let exercise = ExerciseMetadata {
+        id: None,
+        name: "Squat".to_string(),
+        set_type_config: SetTypeConfig::Weighted {
+            min_weight: 20.0,
+            increment: 2.5,
+        },
+        min_reps: 1,
+        max_reps: None,
+    };
+    let id = db.save_exercise(&exercise).await.expect("save_exercise failed");
+    (db, id)
+}
+
+/// Milliseconds per day constant for test date arithmetic.
+const MS_PER_DAY: f64 = 86_400_000.0;
+
+/// get_best_set_for_exercise returns the set with the highest e1RM in the window.
+#[wasm_bindgen_test]
+async fn test_best_set_returns_highest_e1rm() {
+    let (db, eid) = setup_exercise_for_history().await;
+
+    // "Today" = day 10, history window starts at day 0.
+    let day = |d: i64| d as f64 * MS_PER_DAY;
+    let today_start = day(10);
+    let today_end = day(11);
+
+    // Set A: 100kg x 5 @ RPE 8 on day 3
+    let set_a = CompletedSet {
+        set_number: 1,
+        reps: 5,
+        rpe: 8.0,
+        set_type: SetType::Weighted { weight: 100.0 },
+    };
+    db.log_set_at(eid, &set_a, day(3) + 1000.0).await.expect("log A");
+
+    // Set B: 120kg x 3 @ RPE 9 on day 5 — higher e1RM
+    let set_b = CompletedSet {
+        set_number: 1,
+        reps: 3,
+        rpe: 9.0,
+        set_type: SetType::Weighted { weight: 120.0 },
+    };
+    db.log_set_at(eid, &set_b, day(5) + 1000.0).await.expect("log B");
+
+    // Set C: 80kg x 8 @ RPE 7 on day 7 — lower e1RM
+    let set_c = CompletedSet {
+        set_number: 1,
+        reps: 8,
+        rpe: 7.0,
+        set_type: SetType::Weighted { weight: 80.0 },
+    };
+    db.log_set_at(eid, &set_c, day(7) + 1000.0).await.expect("log C");
+
+    let best = db
+        .get_best_set_for_exercise(eid, day(0), today_start, today_end)
+        .await
+        .expect("query failed");
+
+    assert!(best.is_some(), "Should find a best set");
+    let best = best.unwrap();
+    // Set B (120kg x 3 @ RPE 9) should have highest e1RM
+    assert_eq!(best.reps, 3);
+    if let SetType::Weighted { weight } = best.set_type {
+        assert_eq!(weight, 120.0);
+    } else {
+        panic!("Expected Weighted set");
+    }
+}
+
+/// get_best_set_for_exercise excludes sets that fall on the excluded date.
+#[wasm_bindgen_test]
+async fn test_best_set_excludes_today() {
+    let (db, eid) = setup_exercise_for_history().await;
+
+    let day = |d: i64| d as f64 * MS_PER_DAY;
+    let today_start = day(10);
+    let today_end = day(11);
+
+    // Best set is on "today" — should be excluded
+    let set_today = CompletedSet {
+        set_number: 1,
+        reps: 1,
+        rpe: 10.0,
+        set_type: SetType::Weighted { weight: 200.0 },
+    };
+    db.log_set_at(eid, &set_today, today_start + 5000.0).await.expect("log today");
+
+    // Weaker set in history — should be returned
+    let set_history = CompletedSet {
+        set_number: 1,
+        reps: 5,
+        rpe: 8.0,
+        set_type: SetType::Weighted { weight: 100.0 },
+    };
+    db.log_set_at(eid, &set_history, day(5) + 1000.0).await.expect("log history");
+
+    let best = db
+        .get_best_set_for_exercise(eid, day(0), today_start, today_end)
+        .await
+        .expect("query failed");
+
+    assert!(best.is_some());
+    let best = best.unwrap();
+    assert_eq!(best.reps, 5, "Should return historical set, not today's");
+    if let SetType::Weighted { weight } = best.set_type {
+        assert_eq!(weight, 100.0);
+    } else {
+        panic!("Expected Weighted set");
+    }
+}
+
+/// get_best_set_for_exercise returns None when history window is empty.
+#[wasm_bindgen_test]
+async fn test_best_set_empty_history() {
+    let (db, eid) = setup_exercise_for_history().await;
+
+    let day = |d: i64| d as f64 * MS_PER_DAY;
+
+    let best = db
+        .get_best_set_for_exercise(eid, day(0), day(10), day(11))
+        .await
+        .expect("query failed");
+
+    assert!(best.is_none(), "No sets → None");
+}
+
+/// get_best_set_for_exercise returns None when all sets fall on excluded date.
+#[wasm_bindgen_test]
+async fn test_best_set_all_sets_today() {
+    let (db, eid) = setup_exercise_for_history().await;
+
+    let day = |d: i64| d as f64 * MS_PER_DAY;
+    let today_start = day(10);
+    let today_end = day(11);
+
+    // Only set is on today
+    let set = CompletedSet {
+        set_number: 1,
+        reps: 5,
+        rpe: 8.0,
+        set_type: SetType::Weighted { weight: 100.0 },
+    };
+    db.log_set_at(eid, &set, today_start + 1000.0).await.expect("log");
+
+    let best = db
+        .get_best_set_for_exercise(eid, day(0), today_start, today_end)
+        .await
+        .expect("query failed");
+
+    assert!(best.is_none(), "All sets on excluded date → None");
+}
+
+/// get_best_set_for_exercise respects since_date boundary.
+#[wasm_bindgen_test]
+async fn test_best_set_respects_since_date() {
+    let (db, eid) = setup_exercise_for_history().await;
+
+    let day = |d: i64| d as f64 * MS_PER_DAY;
+
+    // Strong set on day 2 (before window)
+    let old_set = CompletedSet {
+        set_number: 1,
+        reps: 1,
+        rpe: 10.0,
+        set_type: SetType::Weighted { weight: 200.0 },
+    };
+    db.log_set_at(eid, &old_set, day(2) + 1000.0).await.expect("log old");
+
+    // Weaker set on day 8 (inside window)
+    let recent_set = CompletedSet {
+        set_number: 1,
+        reps: 5,
+        rpe: 8.0,
+        set_type: SetType::Weighted { weight: 100.0 },
+    };
+    db.log_set_at(eid, &recent_set, day(8) + 1000.0).await.expect("log recent");
+
+    // Window starts at day 5, so old_set (day 2) is excluded
+    let best = db
+        .get_best_set_for_exercise(eid, day(5), day(10), day(11))
+        .await
+        .expect("query failed");
+
+    assert!(best.is_some());
+    let best = best.unwrap();
+    assert_eq!(best.reps, 5, "Should only see set within window");
+}
+
+/// get_latest_set_today returns the most recently logged set today.
+#[wasm_bindgen_test]
+async fn test_latest_set_today_returns_most_recent() {
+    let (db, eid) = setup_exercise_for_history().await;
+
+    let day = |d: i64| d as f64 * MS_PER_DAY;
+    let today_start = day(10);
+    let today_end = day(11);
+
+    // Earlier set today
+    let set_early = CompletedSet {
+        set_number: 1,
+        reps: 5,
+        rpe: 7.0,
+        set_type: SetType::Weighted { weight: 80.0 },
+    };
+    db.log_set_at(eid, &set_early, today_start + 1000.0).await.expect("log early");
+
+    // Later set today
+    let set_late = CompletedSet {
+        set_number: 2,
+        reps: 3,
+        rpe: 9.0,
+        set_type: SetType::Weighted { weight: 100.0 },
+    };
+    db.log_set_at(eid, &set_late, today_start + 5000.0).await.expect("log late");
+
+    let latest = db
+        .get_latest_set_today(eid, today_start, today_end)
+        .await
+        .expect("query failed");
+
+    assert!(latest.is_some());
+    let latest = latest.unwrap();
+    assert_eq!(latest.set_number, 2, "Should return most recent set");
+    assert_eq!(latest.reps, 3);
+}
+
+/// get_latest_set_today returns None when no sets logged today.
+#[wasm_bindgen_test]
+async fn test_latest_set_today_none_when_empty() {
+    let (db, eid) = setup_exercise_for_history().await;
+
+    let day = |d: i64| d as f64 * MS_PER_DAY;
+
+    let latest = db
+        .get_latest_set_today(eid, day(10), day(11))
+        .await
+        .expect("query failed");
+
+    assert!(latest.is_none(), "No sets today → None");
+}
+
+/// get_latest_set_today only returns sets from the specified day.
+#[wasm_bindgen_test]
+async fn test_latest_set_today_ignores_other_days() {
+    let (db, eid) = setup_exercise_for_history().await;
+
+    let day = |d: i64| d as f64 * MS_PER_DAY;
+    let today_start = day(10);
+    let today_end = day(11);
+
+    // Set from yesterday — should not appear
+    let yesterday_set = CompletedSet {
+        set_number: 1,
+        reps: 5,
+        rpe: 8.0,
+        set_type: SetType::Weighted { weight: 100.0 },
+    };
+    db.log_set_at(eid, &yesterday_set, day(9) + 5000.0).await.expect("log yesterday");
+
+    let latest = db
+        .get_latest_set_today(eid, today_start, today_end)
+        .await
+        .expect("query failed");
+
+    assert!(latest.is_none(), "Yesterday's set should not appear");
+}


### PR DESCRIPTION
## Summary

Closes #131

- Add `get_best_set_for_exercise(exercise_id, since_ms, exclude_start_ms, exclude_end_ms)` — fetches all weighted sets in the history window (excluding a date range, typically today), ranks by e1RM in Rust using `domain::e1rm::e1rm()`, returns the best as `Option<CompletedSet>`
- Add `get_latest_set_today(exercise_id, today_start_ms, today_end_ms)` — returns the most recently logged set for an exercise within a day boundary as `Option<CompletedSet>`
- Extract `parse_completed_set_row()` helper to DRY the `CompletedSet` row-parsing pattern

## Design decisions

- **e1RM ranking in Rust, not SQL**: per issue spec, the pure `e1rm()` function from #129 is reused for comparison. SQL only fetches candidate rows; Rust iterates and picks the max.
- **Bodyweight sets skipped** in `get_best_set_for_exercise`: e1RM is undefined without weight, so `is_bodyweight = 0` filter applied in SQL.
- **Date boundaries as `f64` milliseconds**: consistent with existing `recorded_at` column semantics and `log_set_at` API. Callers pass start-of-day / end-of-day ms boundaries.
- **Half-open intervals** `[start, end)`: standard date-range convention, avoids off-by-one.

## Test plan

- [x] `test_best_set_returns_highest_e1rm` — picks set with max e1RM from multiple candidates
- [x] `test_best_set_excludes_today` — today's stronger set excluded, weaker historical set returned
- [x] `test_best_set_empty_history` — returns `None`
- [x] `test_best_set_all_sets_today` — all sets on excluded date → `None`
- [x] `test_best_set_respects_since_date` — set before `since_ms` ignored
- [x] `test_latest_set_today_returns_most_recent` — later set wins over earlier
- [x] `test_latest_set_today_none_when_empty` — returns `None`
- [x] `test_latest_set_today_ignores_other_days` — yesterday's set not returned

All tests are `wasm_bindgen_test` integration tests against real SQLite (no mocks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)