### PR TITLE
feat: settings persistence and UI

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -2410,6 +2410,12 @@ details.collapse summary::-webkit-details-marker {
       var(--focus-shadow, 0 0),
       calc(var(--filler-size) * -1 - var(--filler-offset)) 0 0 var(--filler-size);
 }
+.range-primary {
+  --range-shdw: var(--fallback-p,oklch(var(--p)/1));
+}
+.range-secondary {
+  --range-shdw: var(--fallback-s,oklch(var(--s)/1));
+}
 .range-accent {
   --range-shdw: var(--fallback-a,oklch(var(--a)/1));
 }
@@ -3641,6 +3647,9 @@ details.collapse summary::-webkit-details-marker {
 .text-center {
   text-align: center;
 }
+.font-mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+}
 .text-2xl {
   font-size: 1.5rem;
   line-height: 2rem;
@@ -3758,6 +3767,9 @@ details.collapse summary::-webkit-details-marker {
 .text-warning-content {
   --tw-text-opacity: 1;
   color: var(--fallback-wac,oklch(var(--wac)/var(--tw-text-opacity, 1)));
+}
+.opacity-60 {
+  opacity: 0.6;
 }
 .opacity-70 {
   opacity: 0.7;

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,5 +1,4 @@
 use crate::components::conflict_resolution::ConflictResolutionScreen;
-use crate::components::data_management::DataManagementPanel;
 #[cfg(debug_assertions)]
 use crate::components::debug_panel::DebugPanel;
 use crate::components::exercise_form::ExerciseForm;
@@ -7,6 +6,7 @@ use crate::components::history_view::HistoryView;
 use crate::components::library_view::LibraryView;
 use crate::components::previous_sessions::PreviousSessions;
 use crate::components::rpe_slider::RPESlider;
+use crate::components::settings_view::SettingsView;
 use crate::components::step_controls::StepControls;
 use crate::components::sync_status_indicator::SyncStatusIndicator;
 use crate::components::tab_bar::{Tab, TabBar};
@@ -266,24 +266,7 @@ fn LibraryTab() -> Element {
 #[component]
 fn SettingsTab() -> Element {
     let state = consume_context::<WorkoutState>();
-    rsx! {
-        div {
-            class: "max-w-md mx-auto py-6",
-            h2 { class: "text-xl font-black uppercase tracking-tight mb-6", "Settings" }
-            div {
-                class: "card bg-base-100 shadow-xl",
-                div {
-                    class: "card-body",
-                    h3 { class: "card-title text-base font-bold mb-2", "Data Management" }
-                    p {
-                        class: "text-sm text-base-content/60 mb-4",
-                        "Export your workout database for backup or transfer to another device. Import a previously exported database to restore your data."
-                    }
-                    DataManagementPanel { state }
-                }
-            }
-        }
-    }
+    rsx! { SettingsView { state } }
 }
 
 #[component]

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -8,6 +8,7 @@ pub mod history_view;
 pub mod library_view;
 pub mod previous_sessions;
 pub mod rpe_slider;
+pub mod settings_view;
 pub mod step_controls;
 pub mod sync_status_indicator;
 pub mod tab_bar;

--- a/src/components/settings_view.rs
+++ b/src/components/settings_view.rs
@@ -1,0 +1,163 @@
+use crate::models::Settings;
+use crate::state::{WorkoutState, WorkoutStateManager};
+use dioxus::prelude::*;
+
+/// Clamp and round a value to a given step within [min, max].
+fn clamp_step(value: f64, min: f64, max: f64, step: f64) -> f64 {
+    let clamped = value.clamp(min, max);
+    (clamped / step).round() * step
+}
+
+#[component]
+pub fn SettingsView(state: WorkoutState) -> Element {
+    let settings = state.settings();
+
+    // Persist a single-field change immediately.
+    let persist = move |updated: Settings| {
+        spawn(async move {
+            if let Err(e) = WorkoutStateManager::update_settings(&state, updated).await {
+                log::warn!("Failed to persist settings: {}", e);
+            }
+        });
+    };
+
+    rsx! {
+        div {
+            class: "max-w-md mx-auto py-6",
+            "data-testid": "settings-view",
+            h2 { class: "text-xl font-black uppercase tracking-tight mb-6", "Settings" }
+
+            // ── Algorithm settings card ──────────────────────────────────────
+            div {
+                class: "card bg-base-100 shadow-xl mb-6",
+                div {
+                    class: "card-body",
+                    h3 { class: "card-title text-base font-bold mb-4", "Algorithm Tuning" }
+
+                    // Target RPE slider (6.0 – 10.0, step 0.5)
+                    div {
+                        class: "form-control mb-6",
+                        label {
+                            class: "label",
+                            span { class: "label-text font-semibold", "Target RPE" }
+                            span {
+                                class: "label-text-alt font-mono text-lg",
+                                "data-testid": "target-rpe-value",
+                                "{settings.target_rpe:.1}"
+                            }
+                        }
+                        input {
+                            r#type: "range",
+                            min: "6.0",
+                            max: "10.0",
+                            step: "0.5",
+                            value: "{settings.target_rpe}",
+                            class: "range range-primary",
+                            "data-testid": "target-rpe-slider",
+                            oninput: move |evt| {
+                                if let Ok(val) = evt.value().parse::<f64>() {
+                                    let val = clamp_step(val, 6.0, 10.0, 0.5);
+                                    let mut s = settings;
+                                    s.target_rpe = val;
+                                    persist(s);
+                                }
+                            }
+                        }
+                        div {
+                            class: "flex justify-between text-xs opacity-60 px-1 mt-1",
+                            span { "6" }
+                            span { "7" }
+                            span { "8" }
+                            span { "9" }
+                            span { "10" }
+                        }
+                    }
+
+                    // History window days (numeric input)
+                    div {
+                        class: "form-control mb-6",
+                        label {
+                            class: "label",
+                            span { class: "label-text font-semibold", "History Window (days)" }
+                        }
+                        input {
+                            r#type: "number",
+                            min: "1",
+                            max: "365",
+                            value: "{settings.history_window_days}",
+                            class: "input input-bordered w-full",
+                            "data-testid": "history-window-input",
+                            oninput: move |evt| {
+                                if let Ok(val) = evt.value().parse::<i32>()
+                                    && val > 0
+                                {
+                                    let mut s = settings;
+                                    s.history_window_days = val;
+                                    persist(s);
+                                }
+                            }
+                        }
+                        label {
+                            class: "label",
+                            span {
+                                class: "label-text-alt opacity-60",
+                                "Number of past days to consider for suggestions"
+                            }
+                        }
+                    }
+
+                    // Today blend factor slider (0.0 – 1.0, step 0.1)
+                    div {
+                        class: "form-control mb-2",
+                        label {
+                            class: "label",
+                            span { class: "label-text font-semibold", "Today Blend Factor" }
+                            span {
+                                class: "label-text-alt font-mono text-lg",
+                                "data-testid": "blend-factor-value",
+                                "{settings.today_blend_factor:.1}"
+                            }
+                        }
+                        input {
+                            r#type: "range",
+                            min: "0.0",
+                            max: "1.0",
+                            step: "0.1",
+                            value: "{settings.today_blend_factor}",
+                            class: "range range-secondary",
+                            "data-testid": "blend-factor-slider",
+                            oninput: move |evt| {
+                                if let Ok(val) = evt.value().parse::<f64>() {
+                                    let val = clamp_step(val, 0.0, 1.0, 0.1);
+                                    let mut s = settings;
+                                    s.today_blend_factor = val;
+                                    persist(s);
+                                }
+                            }
+                        }
+                        div {
+                            class: "flex justify-between text-xs opacity-60 px-1 mt-1",
+                            span { "History" }
+                            span { "Balanced" }
+                            span { "Today" }
+                        }
+                    }
+                }
+            }
+
+            // ── Data management card (existing) ─────────────────────────────
+            div {
+                class: "card bg-base-100 shadow-xl",
+                div {
+                    class: "card-body",
+                    h3 { class: "card-title text-base font-bold mb-2", "Data Management" }
+                    p {
+                        class: "text-sm text-base-content/60 mb-4",
+                        "Export your workout database for backup or transfer to another device. Import a previously exported database to restore your data."
+                    }
+                    crate::components::data_management::DataManagementPanel { state }
+                }
+            }
+        }
+    }
+}

--- a/src/models/settings.rs
+++ b/src/models/settings.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 
 /// Global application settings, stored as a single row in the `settings` table.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq)]
 pub struct Settings {
     /// Target RPE for auto-programming (default: 8.0)
     pub target_rpe: f64,

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -823,6 +823,24 @@ impl Database {
         })
     }
 
+    /// Updates the settings row in the database.
+    pub async fn update_settings(
+        &self,
+        settings: &crate::models::Settings,
+    ) -> Result<(), DatabaseError> {
+        let sql = "UPDATE settings SET target_rpe = ?, history_window_days = ?, today_blend_factor = ? WHERE id = 1";
+        self.execute(
+            sql,
+            &[
+                JsValue::from_f64(settings.target_rpe),
+                JsValue::from_f64(settings.history_window_days as f64),
+                JsValue::from_f64(settings.today_blend_factor),
+            ],
+        )
+        .await?;
+        Ok(())
+    }
+
     /// Returns the most recent set for the given exercise (used for predictions).
     pub async fn get_last_set_for_exercise(
         &self,

--- a/src/state/workout_state.rs
+++ b/src/state/workout_state.rs
@@ -1,4 +1,4 @@
-use crate::models::{CompletedSet, ExerciseMetadata, SetType};
+use crate::models::{CompletedSet, ExerciseMetadata, SetType, Settings};
 use crate::state::{Database, Storage, error::WorkoutError};
 use crate::sync::ConflictRecord;
 use crate::sync::VectorClock;
@@ -96,6 +96,8 @@ pub struct WorkoutState {
     sync_status: Signal<SyncStatus>,
     /// Local vector clock, persisted across sync cycles
     sync_clock: Signal<VectorClock>,
+    /// Global application settings (target RPE, history window, blend factor).
+    settings: Signal<Settings>,
     /// Pending conflicts from a sync merge that the user needs to resolve.
     pending_conflicts: Signal<Vec<ConflictRecord>>,
     /// The merged database blob waiting for conflict resolution before being committed.
@@ -127,6 +129,7 @@ impl WorkoutState {
             file_manager: Signal::new(None),
             last_save_time: Signal::new(0.0),
             exercises: Signal::new(Vec::new()),
+            settings: Signal::new(Settings::default()),
             sync_status: Signal::new(SyncStatus::Idle),
             sync_clock: Signal::new(VectorClock::new()),
             pending_conflicts: Signal::new(Vec::new()),
@@ -214,6 +217,15 @@ impl WorkoutState {
     pub fn set_exercises(&self, exercises: Vec<ExerciseMetadata>) {
         let mut sig = self.exercises;
         sig.set(exercises);
+    }
+
+    pub fn settings(&self) -> Settings {
+        (self.settings)()
+    }
+
+    pub fn set_settings(&self, settings: Settings) {
+        let mut sig = self.settings;
+        sig.set(settings);
     }
 
     pub fn sync_status(&self) -> SyncStatus {
@@ -343,6 +355,10 @@ impl WorkoutStateManager {
 
         if let Err(e) = Self::sync_exercises(state).await {
             js_log(&format!("[DB Init] sync_exercises warning: {}", e));
+        }
+
+        if let Err(e) = Self::load_settings(state).await {
+            js_log(&format!("[DB Init] load_settings warning: {}", e));
         }
 
         state.load_persisted_clock();
@@ -522,6 +538,33 @@ impl WorkoutStateManager {
             exercises.len()
         );
         state.set_exercises(exercises);
+
+        Ok(())
+    }
+
+    /// Load settings from the database into app state.
+    pub async fn load_settings(state: &WorkoutState) -> Result<(), WorkoutError> {
+        let db = state.database().ok_or(WorkoutError::NotInitialized)?;
+        let settings = db.get_settings().await.map_err(WorkoutError::Database)?;
+        state.set_settings(settings);
+        Ok(())
+    }
+
+    /// Persist updated settings to the database and refresh app state.
+    pub async fn update_settings(
+        state: &WorkoutState,
+        settings: Settings,
+    ) -> Result<(), WorkoutError> {
+        let db = state.database().ok_or(WorkoutError::NotInitialized)?;
+        db.update_settings(&settings)
+            .await
+            .map_err(WorkoutError::Database)?;
+        state.set_settings(settings);
+
+        // Auto-save the database file
+        if let Err(e) = Self::save_database(state).await {
+            log::warn!("Auto-save after settings update failed: {}", e);
+        }
 
         Ok(())
     }


### PR DESCRIPTION
## Summary
- Load settings from DB on startup and hold in `WorkoutState` signal, accessible to suggestion algorithm
- Replace placeholder settings tab with real controls: target RPE slider (6.0-10.0, step 0.5), history window days numeric input (min 1), today blend factor slider (0.0-1.0, step 0.1)
- Changes persist immediately to DB on every input (no save button); auto-saves database file after each update
- Add `Database::update_settings()` and `WorkoutStateManager::update_settings()`/`load_settings()` methods
- Derive `Copy` on `Settings` struct (all fields are primitives)

Closes #130

## Test plan
- [ ] On first launch with no existing settings row, app starts with default values (RPE 8.0, window 30, blend 0.5)
- [ ] Settings tab shows three controls: target RPE slider, history window days input, blend factor slider
- [ ] Changing any setting persists immediately -- close and reopen app, changed value still shown
- [ ] RPE slider constrained to 6.0-10.0 step 0.5; window_days rejects <= 0; blend factor constrained to 0.0-1.0 step 0.1
- [ ] Settings values accessible to suggestion algorithm via `state.settings()`
- [ ] Existing app functionality (logging sets, viewing history) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)