### PR TITLE
Add sync-backend Docker image CI to GHCR

### DIFF
--- a/.github/workflows/sync-backend-image.yml
+++ b/.github/workflows/sync-backend-image.yml
@@ -1,0 +1,47 @@
+name: Build and Push Sync Backend Image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "sync-backend/**"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/sync-backend
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha,prefix=
+            type=raw,value=latest
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: sync-backend
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/src/app.rs
+++ b/src/app.rs
@@ -125,15 +125,15 @@ fn Shell() -> Element {
     // (which re-renders whenever the route changes).
     let current_route = route.clone();
     match current_route.clone() {
-        Route::WorkoutTab | Route::WorkoutHistory | Route::WorkoutHistoryExercise { .. } => {
-            if *navigation_state.last_workout_route.peek() != current_route {
-                navigation_state.last_workout_route.set(current_route);
-            }
+        Route::WorkoutTab | Route::WorkoutHistory | Route::WorkoutHistoryExercise { .. }
+            if *navigation_state.last_workout_route.peek() != current_route =>
+        {
+            navigation_state.last_workout_route.set(current_route);
         }
-        Route::LibraryTab | Route::LibraryExercise { .. } => {
-            if *navigation_state.last_library_route.peek() != current_route {
-                navigation_state.last_library_route.set(current_route);
-            }
+        Route::LibraryTab | Route::LibraryExercise { .. }
+            if *navigation_state.last_library_route.peek() != current_route =>
+        {
+            navigation_state.last_library_route.set(current_route);
         }
         _ => {}
     }


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that builds and pushes the sync-backend Docker image to GHCR (`ghcr.io/rob-mur/sync-backend`)
- Triggers on pushes to `main` that modify `sync-backend/` files, plus manual `workflow_dispatch`
- Tags images with both the commit SHA and `latest`

## Context
Part of #135 (deploy sync backend to VPS). The VPS NixOS config will pull from `ghcr.io/rob-mur/sync-backend:latest`.

## Test plan
- [ ] Merge this PR, then verify the workflow runs and the image appears at `ghcr.io/rob-mur/sync-backend`
- [ ] Alternatively, trigger manually via Actions > "Build and Push Sync Backend Image" > Run workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)