### PR TITLE
Wire app to live sync backend (fresh-device push smoke test)

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,12 @@
     <meta name="theme-color" content="#ffffff" />
     <link rel="manifest" href="manifest.json" crossorigin="use-credentials" />
     <link rel="stylesheet" href="styles.css" />
+    <!-- Sync backend URL — replaced at build time by scripts/inject-sync-url.sh.
+         When empty or unset, the Wasm client falls back to "/api" (see src/sync/http.rs). -->
+    <script>
+      window.SYNC_BASE_URL = "%%SYNC_BASE_URL%%";
+    </script>
+
     <script src="sql-wasm.js"></script>
     <script type="module" src="file-handle-storage.js"></script>
     <script type="module" src="db-module.js"></script>

--- a/scripts/inject-sync-url.sh
+++ b/scripts/inject-sync-url.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# inject-sync-url.sh — replace the %%SYNC_BASE_URL%% placeholder in the built
+# index.html with the value of the SYNC_BASE_URL environment variable.
+#
+# Usage:
+#   SYNC_BASE_URL=https://sync.example.com ./scripts/inject-sync-url.sh dist/public/index.html
+#
+# If SYNC_BASE_URL is not set, the placeholder is removed so that the Wasm
+# fallback ("/api") takes effect.
+
+set -euo pipefail
+
+INDEX_FILE="${1:-dist/public/index.html}"
+URL="${SYNC_BASE_URL:-}"
+
+if [ ! -f "$INDEX_FILE" ]; then
+  echo "Error: $INDEX_FILE not found" >&2
+  exit 1
+fi
+
+if [ -z "$URL" ]; then
+  echo "Warning: SYNC_BASE_URL not set — sync will fall back to /api" >&2
+fi
+
+# Use | as sed delimiter since URLs contain slashes
+sed -i "s|%%SYNC_BASE_URL%%|${URL}|g" "$INDEX_FILE"
+
+echo "Injected SYNC_BASE_URL='${URL}' into $INDEX_FILE"

--- a/src/state/workout_state.rs
+++ b/src/state/workout_state.rs
@@ -688,13 +688,14 @@ impl WorkoutStateManager {
         use crate::sync::http::wasm::FetchClient;
         use crate::sync::stub_merge;
 
-        // Check credentials first to short-circuit before the expensive
-        // database export when sync is not configured.
-        let credentials = SyncCredentials::load();
-        if credentials.as_ref().is_none_or(|c| !c.is_valid()) {
-            log::debug!("[Sync] Skipped — no valid sync_id configured");
+        // Load existing credentials or auto-generate new ones on first launch.
+        // This ensures a fresh device bootstraps sync without user interaction (#148).
+        let credentials = SyncCredentials::load_or_generate();
+        if !credentials.is_valid() {
+            log::debug!("[Sync] Skipped — credentials failed validation");
             return;
         }
+        let credentials = Some(credentials);
 
         let db = match state.database() {
             Some(db) => db,

--- a/src/sync/credentials.rs
+++ b/src/sync/credentials.rs
@@ -1,7 +1,8 @@
 use serde::{Deserialize, Serialize};
 
 /// Sync credentials read from OPFS/LocalStorage.
-/// These are written by the pairing flow (#90) and read here.
+/// These are written by the pairing flow (#90) or auto-generated on first
+/// launch (#148) and read here.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SyncCredentials {
     /// UUID identifying the sync slot on the server
@@ -31,6 +32,39 @@ impl SyncCredentials {
             // In unit tests there is no LocalStorage; tests inject credentials directly.
             let _ = CREDS_KEY;
             None
+        }
+    }
+
+    /// Load credentials from LocalStorage, generating and persisting new ones
+    /// if none exist yet.  This is called on first app launch to bootstrap
+    /// sync without user interaction (#148).
+    #[cfg(not(test))]
+    pub fn load_or_generate() -> Self {
+        if let Some(existing) = Self::load() {
+            return existing;
+        }
+        let creds = Self::generate();
+        if let Err(e) = creds.save() {
+            log::warn!("[Sync] Failed to persist auto-generated credentials: {}", e);
+        }
+        creds
+    }
+
+    /// Generate fresh sync credentials using random UUIDs.
+    /// `sync_id` and `device_id` are UUID-v4; `sync_secret` is set to a
+    /// placeholder value because the backend currently uses sync_id-as-credential
+    /// auth (no secret required).
+    pub fn generate() -> Self {
+        let sync_id = uuid::Uuid::new_v4().to_string();
+        let device_id = uuid::Uuid::new_v4().to_string();
+        // The sync_secret field is required by is_valid() but the backend does
+        // not enforce it yet.  Use a generated UUID so the credential passes
+        // validation and is ready when the backend adds secret-based auth.
+        let sync_secret = uuid::Uuid::new_v4().to_string();
+        Self {
+            sync_id,
+            sync_secret,
+            device_id,
         }
     }
 
@@ -196,6 +230,42 @@ mod tests {
             device_id: "device-1".into(),
         };
         assert!(creds.is_valid());
+    }
+
+    #[test]
+    fn test_generate_produces_valid_credentials() {
+        let creds = SyncCredentials::generate();
+        assert!(creds.is_valid(), "Generated credentials must be valid");
+        assert!(!creds.sync_id.is_empty());
+        assert!(!creds.sync_secret.is_empty());
+        assert!(!creds.device_id.is_empty());
+    }
+
+    #[test]
+    fn test_generate_produces_unique_ids() {
+        let a = SyncCredentials::generate();
+        let b = SyncCredentials::generate();
+        assert_ne!(
+            a.sync_id, b.sync_id,
+            "Each call must produce a unique sync_id"
+        );
+        assert_ne!(
+            a.device_id, b.device_id,
+            "Each call must produce a unique device_id"
+        );
+    }
+
+    #[test]
+    fn test_generated_sync_id_is_uuid_format() {
+        let creds = SyncCredentials::generate();
+        // UUID v4 format: 8-4-4-4-12 hex chars separated by hyphens
+        assert_eq!(creds.sync_id.len(), 36);
+        assert!(
+            creds
+                .sync_id
+                .chars()
+                .all(|c| c.is_ascii_hexdigit() || c == '-')
+        );
     }
 
     #[test]

--- a/src/sync/http.rs
+++ b/src/sync/http.rs
@@ -12,15 +12,16 @@ pub mod wasm {
 
     fn build_url(sync_id: &str, path: &str) -> String {
         // sync_id is the only path component; sync_secret is NEVER in the URL.
-        // The base URL is expected to come from a compile-time env var or config.
-        // For now we read it from the `SYNC_BASE_URL` JS global set at build time,
-        // falling back to "/api" for local development.
+        // Read `window.SYNC_BASE_URL` which is injected into index.html at build
+        // time by scripts/inject-sync-url.sh.  Falls back to "/api" when the
+        // value is absent, empty, or still contains the un-replaced placeholder.
         let base = js_sys::Reflect::get(
             &web_sys::window().unwrap(),
             &wasm_bindgen::JsValue::from_str("SYNC_BASE_URL"),
         )
         .ok()
         .and_then(|v| v.as_string())
+        .filter(|s| !s.is_empty() && !s.contains("%%"))
         .unwrap_or_else(|| "/api".to_string());
 
         format!("{}/sync/{}{}", base.trim_end_matches('/'), sync_id, path)


### PR DESCRIPTION
## Summary

Closes #148

Wires the Wasm app to the live sync backend so a fresh device can auto-generate sync credentials, push its database, and verify the round-trip — the thinnest possible end-to-end validation before the full QR pairing flow (#90).

### Changes

- **SYNC_BASE_URL placeholder in `index.html`** — a `<script>` tag sets `window.SYNC_BASE_URL` to a build-time placeholder (`%%SYNC_BASE_URL%%`). The injection script `scripts/inject-sync-url.sh` replaces it from the `SYNC_BASE_URL` environment variable during the build. If not replaced, the Wasm fallback (`/api`) takes effect.
- **Auto-generated credentials** — `SyncCredentials::generate()` creates UUID-v4 `sync_id`, `device_id`, and `sync_secret` on first launch. `SyncCredentials::load_or_generate()` persists them to LocalStorage automatically without user interaction.
- **`trigger_background_sync` updated** — now calls `load_or_generate()` instead of `load()`, so the existing push-on-ready path works for fresh devices.
- **Hardened `build_url`** — filters out empty strings and un-replaced `%%` placeholders before using `SYNC_BASE_URL`.
- **Unit tests** — 3 new tests for credential generation (validity, uniqueness, UUID format).

### CI workflow changes (manual step required)

The OAuth token used by this environment lacks the `workflow` scope needed to push `.github/workflows/` changes. The following workflow edits need to be applied manually by a maintainer:

**`.github/workflows/build-and-deploy.yml`:**
- Add `SYNC_BASE_URL` (required: false) to the `secrets:` section
- Add an "Inject SYNC_BASE_URL" step after "Build project" that runs `bash scripts/inject-sync-url.sh dist/public/index.html`

**`.github/workflows/deploy.yml`:**
- Add the same "Inject SYNC_BASE_URL" step after "Build project" in the `build` job
- Forward `SYNC_BASE_URL: ${{ secrets.SYNC_BASE_URL }}` to the reusable workflow in `deploy-production`

### Deployment prerequisite

Set the `SYNC_BASE_URL` repository secret to the live sync backend URL before deploying.

## QA Checklist

From ralph-assess:

- [ ] A production build has SYNC_BASE_URL configured to point at the live sync backend (not defaulting to /api)
- [ ] Opening the app on a fresh device (no existing credentials in LocalStorage) results in a sync_id and device_id being persisted in LocalStorage without any user interaction
- [ ] After the fresh device generates credentials and has local data, the app automatically pushes the local database blob to the server without manual trigger
- [ ] After a successful push, GET /sync/:sync_id returns the uploaded blob content
- [ ] After a successful push, GET /sync/:sync_id/metadata returns a response containing a valid vector clock
- [ ] No visible UI changes are introduced — the app looks and behaves the same from the user perspective aside from sync occurring in the background