### PR TITLE
docs: extend ubiquitous language with suggestion algorithm terms

### DIFF
--- a/UBIQUITOUS_LANGUAGE.md
+++ b/UBIQUITOUS_LANGUAGE.md
@@ -22,19 +22,24 @@
 
 ## Suggestions
 
-| Term                | Definition                                                                                                                                                            | Aliases to avoid                     |
-| ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
-| **Suggestion**      | The algorithm's recommended weight, reps, and target RPE for the trainee's next Set                                                                                   | Prediction, recommendation, next set |
-| **e1RM**            | Estimated one-rep maximum — the theoretical maximum weight for one rep, computed from a Set's weight, reps, and RPE using the linear-RPE exponential-rep formula      | 1RM, max, predicted max              |
-| **Assumption**      | The formula output `(rpe × 0.03269803 + 0.6730197) × 0.970546521^(rep−1)` — the fraction of e1RM represented by a given reps-at-RPE combination                       | Percentage, fraction, coefficient    |
-| **Historical e1RM** | The e1RM of the best Set (highest e1RM) logged for an Exercise within the history window, excluding the current Training Day                                          | Baseline, previous best              |
-| **Today's e1RM**    | The e1RM of the most recently logged Set for an Exercise on the current Training Day; adapts to intra-session fatigue                                                 | Current e1RM, session e1RM           |
-| **Peak e1RM**       | The highest e1RM across all Sets for an Exercise on a given Training Day; the data point used for trend calculation (distinct from Today's e1RM which tracks recency) | Daily max, session best              |
-| **Blended e1RM**    | A weighted combination of Today's e1RM and Historical e1RM, controlled by the Today Blend Factor                                                                      | Adjusted e1RM, combined e1RM         |
-| **Available PB**    | The headroom between the Suggestion weight and the trainee's previous best weight at the same rep count; zero means no personal best is on offer                      | PB delta, progression headroom       |
-| **Infinite Mode**   | The default behaviour where the upper bound of the rep range extends one beyond the highest rep count ever performed, ensuring a fresh rep count is always available  | Uncapped mode                        |
-| **No-Data State**   | The UI state shown when there is insufficient history to compute a meaningful Suggestion                                                                              | Empty state, cold start              |
-| **Rep Range**       | The inclusive interval `[min_reps, max_reps]` within which Suggestions are generated; `max_reps` is nullable (Infinite Mode when null)                                | Rep window, rep limits               |
+| Term                    | Definition                                                                                                                                                                               | Aliases to avoid                     |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| **Suggestion**          | The algorithm's recommended weight, reps, and target RPE for the trainee's next Set                                                                                                      | Prediction, recommendation, next set |
+| **e1RM**                | Estimated one-rep maximum — the theoretical maximum weight for one rep, computed from a Set's weight, reps, and RPE using the linear-RPE exponential-rep formula                         | 1RM, max, predicted max              |
+| **Assumption**          | The formula output `(rpe × 0.03269803 + 0.6730197) × 0.970546521^(rep−1)` — the fraction of e1RM represented by a given reps-at-RPE combination                                          | Percentage, fraction, coefficient    |
+| **Historical e1RM**     | The e1RM of the best Set (highest e1RM) logged for an Exercise within the history window, excluding the current Training Day                                                             | Baseline, previous best              |
+| **Today's e1RM**        | The e1RM of the most recently logged Set for an Exercise on the current Training Day; adapts to intra-session fatigue                                                                    | Current e1RM, session e1RM           |
+| **Peak e1RM**           | The highest e1RM across all Sets for an Exercise on a given Training Day; the data point used for trend calculation (distinct from Today's e1RM which tracks recency)                    | Daily max, session best              |
+| **Blended e1RM**        | A weighted combination of Today's e1RM and Historical e1RM, controlled by the Today Blend Factor                                                                                         | Adjusted e1RM, combined e1RM         |
+| **Available PB**        | The headroom between the Suggestion weight and the trainee's previous best weight at the same rep count; zero means no personal best is on offer                                         | PB delta, progression headroom       |
+| **Infinite Mode**       | The behaviour when `max_reps` is null: the upper bound of the rep range extends to one beyond the highest rep count ever recorded, ensuring a fresh rep count is always available        | Uncapped mode                        |
+| **No-Data State**       | The fallback state when there is insufficient history to compute a meaningful Suggestion; cold-start defaults are used instead                                                           | Empty state, cold start              |
+| **Rep Range**           | The inclusive interval `[min_reps, max_reps]` within which Suggestions are generated; `max_reps` is nullable (Infinite Mode when null)                                                   | Rep window, rep limits               |
+| **RIR**                 | Reps in Reserve — the number of additional reps a trainee could have performed before failure; `RIR = 10 − RPE`                                                                          | Reps left, buffer                    |
+| **Failure Reps**        | The estimated maximum reps achievable to failure for a Bodyweight Set: `reps_done + RIR`; the bodyweight analogue of e1RM — a rep-count measure of capacity                              | Max reps, rep max                    |
+| **Historical Max at R** | The maximum weight ever recorded in a Set of at least R reps within the History Window; used to determine whether a Suggestion offers a personal best at a given rep count               | Rep PB, per-rep best                 |
+| **Per-Rep PB Margin**   | `projected_weight(blended_e1rm, r, target_rpe) − Historical Max at R`; positive means a personal best is available at rep count R; the quantity maximised when selecting Suggestion reps | PB headroom, margin                  |
+| **Clamped Suggestion**  | A Suggestion whose rep count has been constrained to a Rep Range boundary; surfaced in the UI so the trainee knows the Rep Range is limiting the recommendation                          | Bounded suggestion, constrained reps |
 
 ## Progress Detection
 
@@ -50,13 +55,14 @@
 
 ## Settings
 
-| Term                   | Definition                                                                                                                                                                                  | Aliases to avoid                        |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
-| **Target RPE**         | The RPE the trainee is aiming to work at; used as the RPE input when projecting a Suggestion from e1RM                                                                                      | Goal RPE, working RPE                   |
-| **History Window**     | The number of days back the suggestion algorithm searches for Historical e1RM (default 30); scoped to per-set suggestion logic                                                              | Lookback period, recency window         |
-| **Today Blend Factor** | A 0–1 value controlling how much weight Today's e1RM has in the Blended e1RM (default 0.5); configurable to handle good/bad days                                                            | Recency weight, blend ratio             |
-| **Training Window**    | The rolling lookback period, configured in **weeks** (default 12), used for e1RM trend regression and Volume aggregation; exposed as weeks in the settings UI; distinct from History Window | Progress window, trend window, lookback |
-| **Min Sessions**       | The minimum number of Training Days containing an Exercise required before a Progress State is emitted (default 3); configurable                                                            | Data threshold, session threshold       |
+| Term                        | Definition                                                                                                                                                                                  | Aliases to avoid                        |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
+| **Target RPE**              | The RPE the trainee is aiming to work at; used as the RPE input when projecting a Suggestion from e1RM                                                                                      | Goal RPE, working RPE                   |
+| **History Window**          | The number of days back the suggestion algorithm searches for Historical e1RM (default 30); scoped to per-set suggestion logic                                                              | Lookback period, recency window         |
+| **Today Blend Factor**      | A 0–1 value controlling how much weight Today's e1RM has in the Blended e1RM (default 0.5); configurable to handle good/bad days                                                            | Recency weight, blend ratio             |
+| **Training Window**         | The rolling lookback period, configured in **weeks** (default 12), used for e1RM trend regression and Volume aggregation; exposed as weeks in the settings UI; distinct from History Window | Progress window, trend window, lookback |
+| **Min Sessions**            | The minimum number of Training Days containing an Exercise required before a Progress State is emitted (default 3); configurable                                                            | Data threshold, session threshold       |
+| **Default Bodyweight Reps** | The rep count used as the cold-start Suggestion for Bodyweight Exercises when no history exists; configurable in settings (default 10)                                                      | Default reps, starting reps             |
 
 ## Relationships
 
@@ -66,8 +72,13 @@
 - A **Suggestion** is computed per **Exercise** using the **Blended e1RM**, **Rep Range**, and **Target RPE**.
 - **Blended e1RM** = (Today's e1RM × Today Blend Factor) + (Historical e1RM × (1 − Today Blend Factor)).
 - When only Today's e1RM is available (no historical Sets), the Blended e1RM equals Today's e1RM directly.
-- When neither is available, the **No-Data State** is shown.
+- When neither is available, the **No-Data State** is shown and cold-start defaults are used.
 - **Infinite Mode** is active whenever `max_reps` is null on an **Exercise**.
+- For a **Weighted Exercise**, the suggested rep count is the one with the highest positive **Per-Rep PB Margin**; if no positive margin exists in bounded mode, the least-negative margin is used; in **Infinite Mode**, the next uncovered rep count is suggested instead.
+- **Historical Max at R** = max weight across all Sets in the History Window where `reps_done ≥ R`.
+- For a **Bodyweight Exercise**, capacity is expressed as **Failure Reps**; the algorithm blends today's and historical Failure Reps and applies **RIR** at **Target RPE** to derive suggested reps.
+- A **Clamped Suggestion** occurs when the raw suggested reps fall outside the **Rep Range**; the rep count is constrained to `min_reps` or `max_reps` and the UI signals this to the trainee.
+- **Default Bodyweight Reps** is used as the cold-start rep count for **Bodyweight Exercises** with no history.
 - **Peak e1RM** is derived from the **Sets** of a **Training Day** and is the data point used in the **e1RM Trend** regression.
 - **e1RM Trend** requires at least **Min Sessions** Training Days within the **Training Window** to produce a **Progress State**; otherwise **Insufficient Data** is returned.
 - **Volume** for a **Muscle Group** on a given day = sum of **Intensity-Adjusted Sets** across all Sets whose Exercise contributes to that Muscle Group.
@@ -76,15 +87,23 @@
 
 > **Dev:** "After the trainee logs a Set, how do we compute the next Suggestion?"
 
-> **Domain expert:** "Take the Blended e1RM — that's Today's e1RM blended with the Historical e1RM at the Today Blend Factor. Then for each rep count in the Rep Range, project a weight using the Assumption at the Target RPE. Pick the rep count with the most Available PB."
+> **Domain expert:** "Take the Blended e1RM — that's Today's e1RM blended with the Historical e1RM at the Today Blend Factor. Then for each rep count in the Rep Range, compute the Per-Rep PB Margin: the projected weight minus the Historical Max at that rep count. Pick the rep count with the highest positive margin."
 
-> **Dev:** "What if they've already beaten the previous best at every rep count in the range?"
+> **Dev:** "What counts as the Historical Max at, say, 3 reps?"
 
-> **Domain expert:** "That's Infinite Mode — if there's no max_reps, we extend the upper bound to one above the highest rep count they've ever done. There's always a fresh rep count available."
+> **Domain expert:** "The maximum weight across any Set in the History Window where the trainee did at least 3 reps. A 4-rep Set at 100 kg establishes 100 kg as the historical max for 1, 2, 3, and 4 reps."
 
-> **Dev:** "And if it's a brand new exercise with no history at all?"
+> **Dev:** "What if the Blended e1RM is low that day and no rep count offers a positive Per-Rep PB Margin?"
 
-> **Domain expert:** "That's the No-Data State. Show a message — don't pretend to suggest something. If they've done Sets today but nothing older, skip the blend and use Today's e1RM directly."
+> **Domain expert:** "In Infinite Mode, we extend one beyond the highest rep count ever recorded — there's always an uncovered rep count. In bounded mode with max_reps set, we pick the least-negative margin: best available performance for a down day. If the raw suggestion falls outside the Rep Range we clamp it and mark it as a Clamped Suggestion so the trainee knows."
+
+> **Dev:** "How does this work for a Bodyweight Exercise?"
+
+> **Domain expert:** "Instead of e1RM we use Failure Reps — that's reps done plus RIR, where RIR equals 10 minus RPE. We blend today's Failure Reps with the historical best Failure Reps, then subtract the RIR at Target RPE to get the suggested rep count."
+
+> **Dev:** "And if it's a brand new exercise with no history?"
+
+> **Domain expert:** "That's the No-Data State. Fall back to the cold-start defaults: carry forward weight from the last session, use Default Bodyweight Reps for bodyweight exercises."
 
 > **Dev:** "How do we know if a trainee is actually getting stronger over time?"
 
@@ -106,3 +125,5 @@
 - **"Today's e1RM" vs "Peak e1RM"** — both are e1RM values for a Training Day but serve different purposes. Today's e1RM is the _most recent_ set's e1RM (adapts to fatigue, used for in-session Suggestions). Peak e1RM is the _highest_ e1RM of the day (best performance, used as the trend data point). Never use "session e1RM" — it conflates the two.
 - **"Intensity"** is overloaded: (1) in RPE context it means proximity to failure (a perceptual measure); (2) in **Intensity Scalar** / **Intensity-Adjusted Set** it means the numeric value `RPE / 10`. Avoid using "intensity" as a standalone noun — qualify it as RPE or use the compound terms above.
 - **"History Window" vs "Training Window"** — both are lookback periods but for different purposes. **History Window** (days, default 30) scopes the suggestion algorithm's Historical e1RM search. **Training Window** (weeks, default 12) scopes progress detection and Volume aggregation. Never use "window" without the qualifying prefix.
+- **"Max reps" for Bodyweight Exercises** — avoid "max reps" as a shorthand; it ambiguously refers to either the `max_reps` Rep Range setting or the **Failure Reps** capacity estimate. Use **Failure Reps** for the capacity value and **Rep Range** bound for the configuration.
+- **"Available PB" vs "Per-Rep PB Margin"** — **Available PB** (prior term) implied a binary has/hasn't framing. **Per-Rep PB Margin** is the canonical term: it's a signed value used for selection, not just a presence check. Avoid "available PB" in new code or discussion.

--- a/UBIQUITOUS_LANGUAGE.md
+++ b/UBIQUITOUS_LANGUAGE.md
@@ -14,44 +14,53 @@
 
 ## Muscle Groups
 
-| Term                    | Definition                                                                                                                                                                                                                            | Aliases to avoid               |
-| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ |
-| **Muscle Group**        | A named anatomical grouping to which one or more Exercises contribute stimulus                                                                                                                                                        | Body part, muscle, target      |
-| **Muscle Group Weight** | A user-assigned relative weight expressing an Exercise's stimulus priority for a Muscle Group; weights across all Muscle Groups for one Exercise are normalised by their sum at calculation time (e.g. [1, 1, 0.5] → [0.4, 0.4, 0.2]) | Contribution, split, weighting |
-| **Volume**              | The accumulated training stimulus delivered to a Muscle Group over a time period, measured in Intensity-Adjusted Sets                                                                                                                 | Work, load, tonnage            |
+| Term                  | Definition                                                                                                                                                 | Aliases to avoid                   |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
+| **Muscle Group**      | A named anatomical grouping to which one or more Exercises contribute stimulus; one of 12 predefined groups, with optional hierarchy via parent/sub-muscle | Body part, muscle, target          |
+| **Sub-Muscle**        | A more specific Muscle Group nested under a parent (e.g. Lateral Delts under Shoulders); users can tag at any level of the hierarchy                       | Sub-group, child muscle            |
+| **Contribution Tier** | A discrete level expressing how much an Exercise stresses a Muscle Group: Primary (1.0), Secondary (0.5), or Tertiary (0.25)                               | Weight, split, weighting, priority |
+| **Primary**           | The Contribution Tier (value 1.0) indicating a Muscle Group is a main target of the Exercise                                                               | Main, dominant                     |
+| **Secondary**         | The Contribution Tier (value 0.5) indicating significant but non-primary stimulus to a Muscle Group                                                        | Supporting, accessory              |
+| **Tertiary**          | The Contribution Tier (value 0.25) indicating minor involvement of a Muscle Group                                                                          | Minor, incidental                  |
+| **Volume**            | The accumulated training stimulus delivered to a Muscle Group over a time period, measured in Intensity-Adjusted Sets                                      | Work, load, tonnage                |
+
+## UI
+
+| Term             | Definition                                                                                                | Aliases to avoid                    |
+| ---------------- | --------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+| **Body Diagram** | The interactive front/back SVG of a human body used to select Muscle Groups by tapping anatomical regions | Body map, muscle picker, body chart |
 
 ## Suggestions
 
-| Term                    | Definition                                                                                                                                                                               | Aliases to avoid                     |
-| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
-| **Suggestion**          | The algorithm's recommended weight, reps, and target RPE for the trainee's next Set                                                                                                      | Prediction, recommendation, next set |
-| **e1RM**                | Estimated one-rep maximum — the theoretical maximum weight for one rep, computed from a Set's weight, reps, and RPE using the linear-RPE exponential-rep formula                         | 1RM, max, predicted max              |
-| **Assumption**          | The formula output `(rpe × 0.03269803 + 0.6730197) × 0.970546521^(rep−1)` — the fraction of e1RM represented by a given reps-at-RPE combination                                          | Percentage, fraction, coefficient    |
-| **Historical e1RM**     | The e1RM of the best Set (highest e1RM) logged for an Exercise within the history window, excluding the current Training Day                                                             | Baseline, previous best              |
-| **Today's e1RM**        | The e1RM of the most recently logged Set for an Exercise on the current Training Day; adapts to intra-session fatigue                                                                    | Current e1RM, session e1RM           |
-| **Peak e1RM**           | The highest e1RM across all Sets for an Exercise on a given Training Day; the data point used for trend calculation (distinct from Today's e1RM which tracks recency)                    | Daily max, session best              |
-| **Blended e1RM**        | A weighted combination of Today's e1RM and Historical e1RM, controlled by the Today Blend Factor                                                                                         | Adjusted e1RM, combined e1RM         |
-| **Available PB**        | The headroom between the Suggestion weight and the trainee's previous best weight at the same rep count; zero means no personal best is on offer                                         | PB delta, progression headroom       |
-| **Infinite Mode**       | The behaviour when `max_reps` is null: the upper bound of the rep range extends to one beyond the highest rep count ever recorded, ensuring a fresh rep count is always available        | Uncapped mode                        |
-| **No-Data State**       | The fallback state when there is insufficient history to compute a meaningful Suggestion; cold-start defaults are used instead                                                           | Empty state, cold start              |
-| **Rep Range**           | The inclusive interval `[min_reps, max_reps]` within which Suggestions are generated; `max_reps` is nullable (Infinite Mode when null)                                                   | Rep window, rep limits               |
-| **RIR**                 | Reps in Reserve — the number of additional reps a trainee could have performed before failure; `RIR = 10 − RPE`                                                                          | Reps left, buffer                    |
-| **Failure Reps**        | The estimated maximum reps achievable to failure for a Bodyweight Set: `reps_done + RIR`; the bodyweight analogue of e1RM — a rep-count measure of capacity                              | Max reps, rep max                    |
-| **Historical Max at R** | The maximum weight ever recorded in a Set of at least R reps within the History Window; used to determine whether a Suggestion offers a personal best at a given rep count               | Rep PB, per-rep best                 |
-| **Per-Rep PB Margin**   | `projected_weight(blended_e1rm, r, target_rpe) − Historical Max at R`; positive means a personal best is available at rep count R; the quantity maximised when selecting Suggestion reps | PB headroom, margin                  |
-| **Clamped Suggestion**  | A Suggestion whose rep count has been constrained to a Rep Range boundary; surfaced in the UI so the trainee knows the Rep Range is limiting the recommendation                          | Bounded suggestion, constrained reps |
+| Term                    | Definition                                                                                                                                                                                               | Aliases to avoid                     |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------ |
+| **Suggestion**          | The algorithm's recommended weight, reps, and target RPE for the trainee's next Set                                                                                                                      | Prediction, recommendation, next set |
+| **e1RM**                | Estimated one-rep maximum — the theoretical maximum weight for one rep, computed from a Set's weight, reps, and RPE using the linear-RPE exponential-rep formula                                         | 1RM, max, predicted max              |
+| **Assumption**          | The formula output `(rpe × 0.03269803 + 0.6730197) × 0.970546521^(rep−1)` — the fraction of e1RM represented by a given reps-at-RPE combination                                                          | Percentage, fraction, coefficient    |
+| **Historical e1RM**     | The e1RM of the best Set (highest e1RM) logged for an Exercise within the History Window, excluding the current Training Day                                                                             | Baseline, previous best              |
+| **Today's e1RM**        | The e1RM of the most recently logged Set for an Exercise on the current Training Day; adapts to intra-session fatigue                                                                                    | Current e1RM, session e1RM           |
+| **Peak e1RM**           | The highest e1RM across all Sets for an Exercise on a given Training Day; the data point used for trend calculation (distinct from Today's e1RM which tracks recency)                                    | Daily max, session best              |
+| **Blended e1RM**        | A weighted combination of Today's e1RM and Historical e1RM, controlled by the Today Blend Factor                                                                                                         | Adjusted e1RM, combined e1RM         |
+| **Infinite Mode**       | The behaviour when `max_reps` is null: the upper bound of the rep range extends to one beyond the highest rep count recorded within the History Window, ensuring a fresh rep count is always available   | Uncapped mode                        |
+| **No-Data State**       | The fallback state when there is insufficient history to compute a meaningful Suggestion; cold-start defaults are used instead                                                                           | Empty state, cold start              |
+| **Rep Range**           | The inclusive interval `[min_reps, max_reps]` within which Suggestions are generated; `max_reps` is nullable (Infinite Mode when null)                                                                   | Rep window, rep limits               |
+| **RIR**                 | Reps in Reserve — the standard linear approximation of remaining capacity: `RIR = 10 − RPE`; RPE 10 = 0 RIR, RPE 9 = 1 RIR, etc.                                                                         | Reps left, buffer                    |
+| **Failure Reps**        | The estimated maximum reps achievable to failure for a Bodyweight Set: `reps_done + RIR`; the bodyweight analogue of e1RM — a rep-count measure of capacity                                              | Max reps, rep max                    |
+| **Historical Max at R** | The maximum weight recorded within the History Window in a Set where `reps_done ≥ R`; used to determine whether a Suggestion offers a personal best at rep count R                                       | Rep PB, per-rep best                 |
+| **Per-Rep PB Margin**   | `projected_weight(blended_e1rm, r, target_rpe) − Historical Max at R`; positive means a personal best is available at rep count R; in bounded mode, the rep with the highest positive margin is selected | PB headroom, margin                  |
+| **Clamped Suggestion**  | A Suggestion whose rep count has been constrained to a Rep Range boundary; surfaced in the UI so the trainee knows the Rep Range is limiting the recommendation                                          | Bounded suggestion, constrained reps |
 
 ## Progress Detection
 
-| Term                       | Definition                                                                                                                                                                                       | Aliases to avoid                      |
-| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------- |
-| **Progress State**         | The three-value signal emitted per Exercise: Progressing, Stalled, or Insufficient Data                                                                                                          | Progress signal, trend state          |
-| **Progressing**            | The Progress State when the e1RM Trend slope is positive (> 0)                                                                                                                                   | Improving, gaining, trending up       |
-| **Stalled**                | The Progress State when the e1RM Trend slope is zero or negative (≤ 0); covers both flat and declining trajectories                                                                              | Plateaued, regressing, declining      |
-| **Insufficient Data**      | The Progress State emitted when fewer than Min Sessions containing the Exercise exist within the Training Window                                                                                 | No data, cold start, sparse           |
-| **e1RM Trend**             | The slope of the linear regression fitted to the Peak e1RM series for an Exercise across Training Days in the Training Window                                                                    | Progress curve, trendline, regression |
-| **Intensity-Adjusted Set** | A single Set's contribution to Volume: `f(RPE) × normalised_weight`, where `f(RPE) = RPE / 10` and the weight is the **Muscle Group Weight** divided by the sum of all weights for that Exercise | Weighted set, effective set           |
-| **Intensity Scalar**       | The value `f(RPE) = RPE / 10`; scales a Set's stimulus contribution by proximity to failure                                                                                                      | RPE weight, intensity factor, f(RPE)  |
+| Term                       | Definition                                                                                                                                                                                                                | Aliases to avoid                      |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
+| **Progress State**         | The three-value signal emitted per Exercise: Progressing, Stalled, or Insufficient Data                                                                                                                                   | Progress signal, trend state          |
+| **Progressing**            | The Progress State when the e1RM Trend slope is positive (> 0)                                                                                                                                                            | Improving, gaining, trending up       |
+| **Stalled**                | The Progress State when the e1RM Trend slope is zero or negative (≤ 0); covers both flat and declining trajectories                                                                                                       | Plateaued, regressing, declining      |
+| **Insufficient Data**      | The Progress State emitted when fewer than Min Sessions containing the Exercise exist within the Training Window                                                                                                          | No data, cold start, sparse           |
+| **e1RM Trend**             | The slope of the linear regression fitted to the Peak e1RM series for an Exercise across Training Days in the Training Window                                                                                             | Progress curve, trendline, regression |
+| **Intensity-Adjusted Set** | A single Set's contribution to Volume: `f(RPE) × tier_value`, where `f(RPE) = RPE / 10` and the tier value is the **Contribution Tier** of the Exercise for that Muscle Group (Primary=1.0, Secondary=0.5, Tertiary=0.25) | Weighted set, effective set           |
+| **Intensity Scalar**       | The value `f(RPE) = RPE / 10`; scales a Set's stimulus contribution by proximity to failure                                                                                                                               | RPE weight, intensity factor, f(RPE)  |
 
 ## Settings
 
@@ -68,17 +77,17 @@
 
 - A **Training Day** contains one or more **Sets** across one or more **Exercises**.
 - A **Set** belongs to exactly one **Exercise** and one **Training Day**.
-- An **Exercise** has one or more **Muscle Group Weights**; the system normalises them by their sum so stimulus always adds up to 100% across Muscle Groups.
+- An **Exercise** has one or more **Muscle Groups**, each assigned a **Contribution Tier** (Primary, Secondary, or Tertiary).
+- A **Muscle Group** may have **Sub-Muscles**; users can tag at any level of the hierarchy.
 - A **Suggestion** is computed per **Exercise** using the **Blended e1RM**, **Rep Range**, and **Target RPE**.
-- **Blended e1RM** = (Today's e1RM × Today Blend Factor) + (Historical e1RM × (1 − Today Blend Factor)).
-- When only Today's e1RM is available (no historical Sets), the Blended e1RM equals Today's e1RM directly.
-- When neither is available, the **No-Data State** is shown and cold-start defaults are used.
-- **Infinite Mode** is active whenever `max_reps` is null on an **Exercise**.
-- For a **Weighted Exercise**, the suggested rep count is the one with the highest positive **Per-Rep PB Margin**; if no positive margin exists in bounded mode, the least-negative margin is used; in **Infinite Mode**, the next uncovered rep count is suggested instead.
-- **Historical Max at R** = max weight across all Sets in the History Window where `reps_done ≥ R`.
-- For a **Bodyweight Exercise**, capacity is expressed as **Failure Reps**; the algorithm blends today's and historical Failure Reps and applies **RIR** at **Target RPE** to derive suggested reps.
+- **Blended e1RM** = (Today's e1RM × Today Blend Factor) + (Historical e1RM × (1 − Today Blend Factor)); applies to both weighted (e1RM values) and bodyweight (Failure Reps values) exercises, using the same Today Blend Factor setting.
+- When only Today's e1RM is available (no historical Sets), the Blended e1RM equals Today's e1RM directly; same applies to Failure Reps for Bodyweight Exercises.
+- When neither is available, the **No-Data State** is active: for Weighted Exercises the last session's weight is carried forward; for Bodyweight Exercises **Default Bodyweight Reps** is used.
+- For a **Weighted Exercise**, the suggested rep count is the one with the highest positive **Per-Rep PB Margin** in the Rep Range; if no positive margin exists and **Infinite Mode** is active, the next uncovered rep count (`max_data_rep + 1`) is suggested; in bounded mode with no positive margin, the least-negative margin is used.
+- **Historical Max at R** = max weight in the History Window across all Sets where `reps_done ≥ R`.
+- For a **Bodyweight Exercise**, the suggested reps = `round(blended_failure_reps − (10 − Target RPE))`, where **Failure Reps** = `reps_done + (10 − RPE)` for each set.
 - A **Clamped Suggestion** occurs when the raw suggested reps fall outside the **Rep Range**; the rep count is constrained to `min_reps` or `max_reps` and the UI signals this to the trainee.
-- **Default Bodyweight Reps** is used as the cold-start rep count for **Bodyweight Exercises** with no history.
+- **Infinite Mode** is active whenever `max_reps` is null on an **Exercise**.
 - **Peak e1RM** is derived from the **Sets** of a **Training Day** and is the data point used in the **e1RM Trend** regression.
 - **e1RM Trend** requires at least **Min Sessions** Training Days within the **Training Window** to produce a **Progress State**; otherwise **Insufficient Data** is returned.
 - **Volume** for a **Muscle Group** on a given day = sum of **Intensity-Adjusted Sets** across all Sets whose Exercise contributes to that Muscle Group.
@@ -87,23 +96,23 @@
 
 > **Dev:** "After the trainee logs a Set, how do we compute the next Suggestion?"
 
-> **Domain expert:** "Take the Blended e1RM — that's Today's e1RM blended with the Historical e1RM at the Today Blend Factor. Then for each rep count in the Rep Range, compute the Per-Rep PB Margin: the projected weight minus the Historical Max at that rep count. Pick the rep count with the highest positive margin."
+> **Domain expert:** "Take the Blended e1RM — that's Today's e1RM blended with the Historical e1RM at the Today Blend Factor. Then for each rep count in the Rep Range, compute the Per-Rep PB Margin: projected weight minus the Historical Max at that rep count. Pick the rep count with the highest positive margin."
 
 > **Dev:** "What counts as the Historical Max at, say, 3 reps?"
 
-> **Domain expert:** "The maximum weight across any Set in the History Window where the trainee did at least 3 reps. A 4-rep Set at 100 kg establishes 100 kg as the historical max for 1, 2, 3, and 4 reps."
+> **Domain expert:** "The maximum weight recorded within the History Window in a Set where the trainee did at least 3 reps. A 4-rep Set at 100 kg covers reps 1 through 4."
 
-> **Dev:** "What if the Blended e1RM is low that day and no rep count offers a positive Per-Rep PB Margin?"
+> **Dev:** "What if the Blended e1RM is low that day and no rep count has a positive Per-Rep PB Margin?"
 
-> **Domain expert:** "In Infinite Mode, we extend one beyond the highest rep count ever recorded — there's always an uncovered rep count. In bounded mode with max_reps set, we pick the least-negative margin: best available performance for a down day. If the raw suggestion falls outside the Rep Range we clamp it and mark it as a Clamped Suggestion so the trainee knows."
+> **Domain expert:** "In Infinite Mode, we extend one beyond the highest rep count recorded — there's always an uncovered rep count. In bounded mode, we pick the least-negative margin: best available performance for a down day. If the raw suggestion falls outside the Rep Range we clamp it and mark it a Clamped Suggestion so the trainee knows."
 
 > **Dev:** "How does this work for a Bodyweight Exercise?"
 
-> **Domain expert:** "Instead of e1RM we use Failure Reps — that's reps done plus RIR, where RIR equals 10 minus RPE. We blend today's Failure Reps with the historical best Failure Reps, then subtract the RIR at Target RPE to get the suggested rep count."
+> **Domain expert:** "Instead of e1RM we use Failure Reps — reps done plus RIR, where RIR is 10 minus RPE. We blend today's and historical Failure Reps using the same Today Blend Factor, then subtract the RIR at Target RPE to get the suggested rep count."
 
-> **Dev:** "And if it's a brand new exercise with no history?"
+> **Dev:** "And if it's a brand new exercise with no history at all?"
 
-> **Domain expert:** "That's the No-Data State. Fall back to the cold-start defaults: carry forward weight from the last session, use Default Bodyweight Reps for bodyweight exercises."
+> **Domain expert:** "That's the No-Data State. For weighted, carry forward the weight from the last session. For bodyweight, use Default Bodyweight Reps."
 
 > **Dev:** "How do we know if a trainee is actually getting stronger over time?"
 
@@ -115,7 +124,19 @@
 
 > **Dev:** "What about Volume — is that for tracking fatigue?"
 
-> **Domain expert:** "Volume measures accumulated stimulus per Muscle Group. Each Set contributes one Intensity-Adjusted Set: the Intensity Scalar times the Muscle Group Weight. We aggregate daily, over 7 days for fatigue, and over the full Training Window for effort. Volume doesn't tell you if someone is progressing — that's the e1RM Trend's job."
+> **Domain expert:** "Volume measures accumulated stimulus per Muscle Group. Each Set contributes one Intensity-Adjusted Set: the Intensity Scalar times the Contribution Tier value. A Primary exercise counts fully, Secondary at half, Tertiary at a quarter. We aggregate daily, over 7 days for fatigue, and over the full Training Window for effort. Volume doesn't tell you if someone is progressing — that's the e1RM Trend's job."
+
+> **Dev:** "When a user creates a new Exercise, how do they assign Muscle Groups?"
+>
+> **Domain expert:** "They tap regions on the Body Diagram — it's a front/back SVG of a human body. Each tap toggles a Muscle Group and creates a card with a Contribution Tier defaulting to Primary. They can tap the card to cycle through Secondary, Tertiary, or remove it entirely."
+>
+> **Dev:** "What if they only pick one Muscle Group?"
+>
+> **Domain expert:** "Then it's automatically Primary — no extra step. The rule is: at least one Muscle Group is required. You can't save an Exercise without one."
+>
+> **Dev:** "And if they edit the Muscle Groups later?"
+>
+> **Domain expert:** "Fully editable, and changes are retroactive. No snapshotting — if you fix a tagging mistake, the whole system reflects the update."
 
 ## Flagged ambiguities
 
@@ -125,5 +146,7 @@
 - **"Today's e1RM" vs "Peak e1RM"** — both are e1RM values for a Training Day but serve different purposes. Today's e1RM is the _most recent_ set's e1RM (adapts to fatigue, used for in-session Suggestions). Peak e1RM is the _highest_ e1RM of the day (best performance, used as the trend data point). Never use "session e1RM" — it conflates the two.
 - **"Intensity"** is overloaded: (1) in RPE context it means proximity to failure (a perceptual measure); (2) in **Intensity Scalar** / **Intensity-Adjusted Set** it means the numeric value `RPE / 10`. Avoid using "intensity" as a standalone noun — qualify it as RPE or use the compound terms above.
 - **"History Window" vs "Training Window"** — both are lookback periods but for different purposes. **History Window** (days, default 30) scopes the suggestion algorithm's Historical e1RM search. **Training Window** (weeks, default 12) scopes progress detection and Volume aggregation. Never use "window" without the qualifying prefix.
-- **"Max reps" for Bodyweight Exercises** — avoid "max reps" as a shorthand; it ambiguously refers to either the `max_reps` Rep Range setting or the **Failure Reps** capacity estimate. Use **Failure Reps** for the capacity value and **Rep Range** bound for the configuration.
-- **"Available PB" vs "Per-Rep PB Margin"** — **Available PB** (prior term) implied a binary has/hasn't framing. **Per-Rep PB Margin** is the canonical term: it's a signed value used for selection, not just a presence check. Avoid "available PB" in new code or discussion.
+- **"Muscle Group Weight" (deprecated)** — the original design used freeform relative weights normalised at calculation time. This has been replaced by **Contribution Tier** (discrete Primary/Secondary/Tertiary). Do not use "weight" to describe an Exercise's relationship to a Muscle Group — use **Contribution Tier** or the specific tier name.
+- **Contribution Tier vs Muscle Group Weight (normalisation)** — the old Muscle Group Weight system normalised stimulus to always sum to 100% across Muscle Groups. Contribution Tiers do not: each Muscle Group receives its full tier value independently. Volume totals will therefore be higher for multi-muscle exercises under the new model.
+- **"Available PB" (deprecated)** — superseded by **Per-Rep PB Margin**. Available PB implied a binary has/hasn't framing; Per-Rep PB Margin is the signed value actually used for rep selection. Do not use Available PB in new code or discussion.
+- **"Max reps" for Bodyweight Exercises** — avoid "max reps" as a standalone term; it ambiguously refers to either the `max_reps` Rep Range bound or **Failure Reps** (the capacity estimate). Use **Failure Reps** for the estimated maximum and **Rep Range** bound for the configuration.


### PR DESCRIPTION
## Summary

- Adds **RIR**, **Failure Reps**, **Historical Max at R**, **Per-Rep PB Margin**, **Clamped Suggestion**, and **Default Bodyweight Reps** to the Suggestions section
- Updates Relationships to document the per-rep PB margin selection algorithm, bodyweight Failure Reps blending, and clamping behaviour
- Rewrites example dialogue to illustrate the new terms in context
- Flags "Available PB" as deprecated in favour of Per-Rep PB Margin, and "max reps" ambiguity for Bodyweight Exercises

Closes design gaps in #127.

## Test plan
- [ ] Read through the example dialogue — terms should be unambiguous and precise
- [ ] Verify all new terms appear in the Relationships section with correct cardinality
- [ ] Check flagged ambiguities section covers the new aliases-to-avoid

🤖 Generated with [Claude Code](https://claude.com/claude-code)