### PR TITLE
Initial sync must union-merge pre-existing local data

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,7 +10,7 @@ import { defineBddConfig } from "playwright-bdd";
 const testDir = defineBddConfig({
   features: "tests/e2e/features/**/*.feature",
   steps: "tests/e2e/steps/**/*.ts",
-  tags: "@e2e",
+  tags: process.env.SYNC_BACKEND ? "@e2e" : "@e2e and not @sync-backend",
 });
 
 const baseURL = process.env.PLAYWRIGHT_BASE_URL || "http://localhost:3000";

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,7 +10,7 @@ import { defineBddConfig } from "playwright-bdd";
 const testDir = defineBddConfig({
   features: "tests/e2e/features/**/*.feature",
   steps: "tests/e2e/steps/**/*.ts",
-  tags: process.env.SYNC_BACKEND ? "@e2e" : "@e2e and not @sync-backend",
+  tags: "@e2e",
 });
 
 const baseURL = process.env.PLAYWRIGHT_BASE_URL || "http://localhost:3000";

--- a/src/state/workout_state.rs
+++ b/src/state/workout_state.rs
@@ -734,9 +734,38 @@ impl WorkoutStateManager {
         let mut clock = state.sync_clock();
 
         let client = SyncClient::new(FetchClient);
-        let outcome = client
-            .run(credentials.as_ref(), &local_blob, &mut clock, &stub_merge)
-            .await;
+
+        // If the local clock is empty this is a first-ever sync.  Use the
+        // initial-sync path which inspects the server state first so that
+        // pre-existing local data is never silently overwritten (#149).
+        let outcome = if clock.is_empty() {
+            // Determine whether the local DB actually contains user data.
+            // An empty exercise list means there is nothing worth preserving.
+            let local_has_data = match db.get_exercises().await {
+                Ok(exercises) => !exercises.is_empty(),
+                Err(e) => {
+                    log::warn!(
+                        "[Sync] Could not query exercises for initial sync check: {}",
+                        e
+                    );
+                    // Conservative: assume data exists to avoid silent loss.
+                    true
+                }
+            };
+            client
+                .run_initial_sync(
+                    credentials.as_ref(),
+                    &local_blob,
+                    !local_has_data,
+                    &mut clock,
+                    &stub_merge,
+                )
+                .await
+        } else {
+            client
+                .run(credentials.as_ref(), &local_blob, &mut clock, &stub_merge)
+                .await
+        };
 
         // Only persist the updated clock when the sync cycle actually reached
         // the server.  Persisting after Offline would accumulate meaningless

--- a/src/sync/client.rs
+++ b/src/sync/client.rs
@@ -231,6 +231,201 @@ impl<H: HttpClient> SyncClient<H> {
             }
         }
     }
+
+    /// Run an initial sync cycle for a device that has never synced before.
+    ///
+    /// This method is called when the local vector clock is empty, indicating
+    /// the device is syncing for the first time. It inspects both the local
+    /// database (via `local_blob`) and the server state to choose the correct
+    /// strategy, per the table in issue #149:
+    ///
+    /// | Local DB  | Server slot  | Action                                    |
+    /// |-----------|-------------|-------------------------------------------|
+    /// | Empty     | Empty (404) | No-op                                     |
+    /// | Has data  | Empty (404) | Push local DB (normal first push)         |
+    /// | Empty     | Has data    | Pull server blob (fast-forward)           |
+    /// | Has data  | Has data    | Push local first → merge → push merged    |
+    ///
+    /// `local_blob_is_empty` indicates whether the local database has any
+    /// meaningful data (as determined by the caller — typically checking
+    /// whether the exported blob represents an empty database).
+    pub async fn run_initial_sync(
+        &self,
+        credentials: Option<&SyncCredentials>,
+        local_blob: &[u8],
+        local_blob_is_empty: bool,
+        local_clock: &mut VectorClock,
+        merge_fn: &dyn Fn(&[u8], &[u8]) -> MergeResult,
+    ) -> SyncOutcome {
+        let Some(creds) = credentials else {
+            return SyncOutcome::Skipped;
+        };
+
+        if !creds.is_valid() {
+            return SyncOutcome::Skipped;
+        }
+
+        // Step 1: probe the server to determine whether a slot already exists.
+        let server_state = match self
+            .http
+            .get_metadata(&creds.sync_id, &creds.sync_secret)
+            .await
+        {
+            Ok(m) => Some(m),
+            Err(SyncError::ServerError(404)) => None,
+            Err(e) => {
+                log::warn!(
+                    "[Sync] Initial sync: metadata probe failed (offline?): {}",
+                    e
+                );
+                return SyncOutcome::Offline;
+            }
+        };
+
+        match (local_blob_is_empty, &server_state) {
+            // ── Case 1: both empty → no-op ──────────────────────────────
+            (true, None) => {
+                log::debug!("[Sync] Initial sync: both local and server empty → no-op");
+                SyncOutcome::Skipped
+            }
+
+            // ── Case 2: local has data, server empty → normal first push ─
+            (false, None) => {
+                log::debug!("[Sync] Initial sync: local has data, server empty → push");
+                let mut tentative_clock = local_clock.clone();
+                tentative_clock.increment(&creds.device_id);
+
+                let push_req = PushRequest {
+                    vector_clock: tentative_clock.clone(),
+                    blob_b64: base64_encode(local_blob),
+                };
+
+                if let Err(e) = self
+                    .http
+                    .push(&creds.sync_id, &creds.sync_secret, &push_req)
+                    .await
+                {
+                    log::warn!("[Sync] Initial sync push failed: {}", e);
+                    return SyncOutcome::Offline;
+                }
+
+                *local_clock = tentative_clock;
+                SyncOutcome::Pushed
+            }
+
+            // ── Case 3: local empty, server has data → fast-forward pull ─
+            (true, Some(metadata)) => {
+                log::debug!("[Sync] Initial sync: local empty, server has data → pull");
+                match self
+                    .http
+                    .pull_blob(&creds.sync_id, &creds.sync_secret)
+                    .await
+                {
+                    Ok(blob) => {
+                        local_clock.merge(&metadata.vector_clock);
+                        SyncOutcome::Pulled(blob)
+                    }
+                    Err(e) => {
+                        log::warn!("[Sync] Initial sync pull failed: {}", e);
+                        SyncOutcome::Offline
+                    }
+                }
+            }
+
+            // ── Case 4: both have data → push-then-merge ────────────────
+            (false, Some(_metadata)) => {
+                log::info!(
+                    "[Sync] Initial sync: both local and server have data → push-then-merge"
+                );
+
+                // Step A: push local blob with our clock to force divergence
+                let mut tentative_clock = local_clock.clone();
+                tentative_clock.increment(&creds.device_id);
+
+                let push_req = PushRequest {
+                    vector_clock: tentative_clock.clone(),
+                    blob_b64: base64_encode(local_blob),
+                };
+
+                if let Err(e) = self
+                    .http
+                    .push(&creds.sync_id, &creds.sync_secret, &push_req)
+                    .await
+                {
+                    log::warn!("[Sync] Initial sync push (for merge) failed: {}", e);
+                    return SyncOutcome::Offline;
+                }
+
+                *local_clock = tentative_clock;
+
+                // Step B: re-fetch metadata to get the server's updated state
+                let metadata = match self
+                    .http
+                    .get_metadata(&creds.sync_id, &creds.sync_secret)
+                    .await
+                {
+                    Ok(m) => m,
+                    Err(e) => {
+                        log::warn!("[Sync] Initial sync metadata re-fetch failed: {}", e);
+                        return SyncOutcome::Offline;
+                    }
+                };
+
+                let server_clock = &metadata.vector_clock;
+
+                // Step C: compare clocks and handle accordingly
+                match local_clock.compare(server_clock) {
+                    ClockRelation::Equal | ClockRelation::AheadOf => {
+                        // Server accepted our push as-is; no merge needed.
+                        // This can happen if the server had already incorporated
+                        // our push into its clock.
+                        SyncOutcome::Pushed
+                    }
+                    ClockRelation::BehindOf | ClockRelation::Concurrent => {
+                        // Diverged or server ahead — pull and merge
+                        let server_blob = match self
+                            .http
+                            .pull_blob(&creds.sync_id, &creds.sync_secret)
+                            .await
+                        {
+                            Ok(b) => b,
+                            Err(e) => {
+                                log::warn!("[Sync] Initial sync pull for merge failed: {}", e);
+                                return SyncOutcome::Offline;
+                            }
+                        };
+
+                        let merge_result = merge_fn(local_blob, &server_blob);
+                        local_clock.merge(server_clock);
+
+                        if !merge_result.conflicts.is_empty() {
+                            return SyncOutcome::ConflictDetected {
+                                merged: merge_result.merged,
+                                conflicts: merge_result.conflicts,
+                            };
+                        }
+
+                        // Push merged result back
+                        let merged_push = PushRequest {
+                            vector_clock: local_clock.clone(),
+                            blob_b64: base64_encode(&merge_result.merged),
+                        };
+
+                        if let Err(e) = self
+                            .http
+                            .push(&creds.sync_id, &creds.sync_secret, &merged_push)
+                            .await
+                        {
+                            log::warn!("[Sync] Initial sync push of merged result failed: {}", e);
+                            return SyncOutcome::Offline;
+                        }
+
+                        SyncOutcome::Merged(merge_result.merged)
+                    }
+                }
+            }
+        }
+    }
 }
 
 // ── Merge result ──────────────────────────────────────────────────────────
@@ -612,5 +807,268 @@ mod tests {
     fn test_base64_encode_padding_two() {
         // "M" → "TQ=="
         assert_eq!(base64_encode(b"M"), "TQ==");
+    }
+
+    // ── MockHttp with 404 support for initial sync tests ────────────────
+
+    /// A mock HTTP client where `get_metadata` returns 404 (server slot empty)
+    /// until a push is made, then returns the provided metadata.
+    #[derive(Clone)]
+    struct MockHttp404 {
+        /// If true, get_metadata returns 404 (server slot does not exist yet)
+        server_empty: Rc<RefCell<bool>>,
+        /// Metadata to return once the server is no longer empty
+        server_metadata: SyncMetadata,
+        server_blob: Vec<u8>,
+        push_calls: Rc<RefCell<u32>>,
+    }
+
+    impl MockHttp404 {
+        /// Server slot is empty (404 on metadata).
+        fn empty() -> Self {
+            Self {
+                server_empty: Rc::new(RefCell::new(true)),
+                server_metadata: SyncMetadata {
+                    vector_clock: VectorClock::new(),
+                    conflicted: false,
+                },
+                server_blob: vec![],
+                push_calls: Rc::new(RefCell::new(0)),
+            }
+        }
+
+        /// Server has existing data.
+        fn with_data(server_clock: VectorClock, server_blob: Vec<u8>) -> Self {
+            Self {
+                server_empty: Rc::new(RefCell::new(false)),
+                server_metadata: SyncMetadata {
+                    vector_clock: server_clock,
+                    conflicted: false,
+                },
+                server_blob,
+                push_calls: Rc::new(RefCell::new(0)),
+            }
+        }
+
+        fn push_call_count(&self) -> u32 {
+            *self.push_calls.borrow()
+        }
+    }
+
+    #[async_trait::async_trait(?Send)]
+    impl HttpClient for MockHttp404 {
+        async fn push(
+            &self,
+            _sync_id: &str,
+            _sync_secret: &str,
+            _body: &PushRequest,
+        ) -> Result<(), SyncError> {
+            *self.push_calls.borrow_mut() += 1;
+            // After a push, the server slot is no longer empty
+            *self.server_empty.borrow_mut() = false;
+            Ok(())
+        }
+
+        async fn get_metadata(
+            &self,
+            _sync_id: &str,
+            _sync_secret: &str,
+        ) -> Result<SyncMetadata, SyncError> {
+            if *self.server_empty.borrow() {
+                return Err(SyncError::ServerError(404));
+            }
+            Ok(self.server_metadata.clone())
+        }
+
+        async fn pull_blob(
+            &self,
+            _sync_id: &str,
+            _sync_secret: &str,
+        ) -> Result<Vec<u8>, SyncError> {
+            if *self.server_empty.borrow() {
+                return Err(SyncError::ServerError(404));
+            }
+            Ok(self.server_blob.clone())
+        }
+    }
+
+    // ── Initial sync: QA checklist tests (#149) ─────────────────────────
+
+    // Case 1: empty local DB + empty server → no-op (Skipped)
+    #[tokio::test]
+    async fn test_initial_sync_both_empty_is_noop() {
+        let http = MockHttp404::empty();
+        let client = SyncClient::new(http.clone());
+        let mut clock = VectorClock::new();
+
+        let outcome = client
+            .run_initial_sync(Some(&creds()), b"", true, &mut clock, &no_op_merge)
+            .await;
+
+        assert_eq!(outcome, SyncOutcome::Skipped);
+        assert_eq!(http.push_call_count(), 0);
+        assert!(clock.is_empty(), "Clock should remain empty after no-op");
+    }
+
+    // Case 2: local has data, server empty (404) → push
+    #[tokio::test]
+    async fn test_initial_sync_local_data_server_empty_pushes() {
+        let http = MockHttp404::empty();
+        let client = SyncClient::new(http.clone());
+        let mut clock = VectorClock::new();
+
+        let outcome = client
+            .run_initial_sync(
+                Some(&creds()),
+                b"local-workout-data",
+                false,
+                &mut clock,
+                &no_op_merge,
+            )
+            .await;
+
+        assert_eq!(outcome, SyncOutcome::Pushed);
+        assert_eq!(http.push_call_count(), 1);
+        assert!(!clock.is_empty(), "Clock should be incremented after push");
+        assert_eq!(clock.get("device-a"), 1);
+    }
+
+    // Case 3: local empty, server has data → fast-forward pull
+    #[tokio::test]
+    async fn test_initial_sync_local_empty_server_has_data_pulls() {
+        let mut server_clock = VectorClock::new();
+        server_clock.increment("device-b");
+        server_clock.increment("device-b");
+        let server_blob = b"server-workout-data".to_vec();
+
+        let http = MockHttp404::with_data(server_clock.clone(), server_blob.clone());
+        let client = SyncClient::new(http.clone());
+        let mut clock = VectorClock::new();
+
+        let outcome = client
+            .run_initial_sync(Some(&creds()), b"", true, &mut clock, &no_op_merge)
+            .await;
+
+        match outcome {
+            SyncOutcome::Pulled(blob) => assert_eq!(blob, server_blob),
+            other => panic!("Expected Pulled, got {:?}", other),
+        }
+        // No pushes should occur for a pure pull
+        assert_eq!(http.push_call_count(), 0);
+        // Clock should have been merged with server
+        assert_eq!(clock.get("device-b"), 2);
+    }
+
+    // Case 4: both have data → push-then-merge preserves both datasets
+    #[tokio::test]
+    async fn test_initial_sync_both_have_data_merges() {
+        // Server has data from device-b
+        let mut server_clock = VectorClock::new();
+        server_clock.increment("device-b");
+        let server_blob = b"server-data".to_vec();
+
+        let http = MockHttp404::with_data(server_clock, server_blob);
+        let client = SyncClient::new(http.clone());
+        let mut clock = VectorClock::new();
+
+        // Use a merge function that concatenates both blobs to prove both
+        // are passed into the merge
+        fn union_merge(a: &[u8], b: &[u8]) -> MergeResult {
+            let mut merged = a.to_vec();
+            merged.extend_from_slice(b);
+            MergeResult {
+                merged,
+                conflicts: vec![],
+            }
+        }
+
+        let outcome = client
+            .run_initial_sync(
+                Some(&creds()),
+                b"local-data",
+                false,
+                &mut clock,
+                &union_merge,
+            )
+            .await;
+
+        match outcome {
+            SyncOutcome::Merged(blob) => {
+                // Merged blob should contain both local and server data
+                assert!(
+                    blob.len() > b"local-data".len(),
+                    "Merged blob should be larger than local alone"
+                );
+                // Verify both blobs contributed
+                let expected: Vec<u8> = b"local-data"
+                    .iter()
+                    .chain(b"server-data")
+                    .copied()
+                    .collect();
+                assert_eq!(blob, expected);
+            }
+            other => panic!("Expected Merged, got {:?}", other),
+        }
+
+        // Should have pushed twice: initial push + merged result push
+        assert_eq!(http.push_call_count(), 2);
+
+        // Clock should reflect both devices
+        assert!(clock.get("device-a") >= 1);
+        assert!(clock.get("device-b") >= 1);
+    }
+
+    // Case 4 with conflicts: both have data and merge produces conflicts
+    #[tokio::test]
+    async fn test_initial_sync_both_have_data_with_conflicts() {
+        let mut server_clock = VectorClock::new();
+        server_clock.increment("device-b");
+
+        let http = MockHttp404::with_data(server_clock, b"server".to_vec());
+        let client = SyncClient::new(http.clone());
+        let mut clock = VectorClock::new();
+
+        let outcome = client
+            .run_initial_sync(Some(&creds()), b"local", false, &mut clock, &conflict_merge)
+            .await;
+
+        match outcome {
+            SyncOutcome::ConflictDetected { conflicts, .. } => {
+                assert_eq!(conflicts.len(), 1);
+                assert_eq!(conflicts[0].row_id, "row-1");
+            }
+            other => panic!("Expected ConflictDetected, got {:?}", other),
+        }
+
+        // Only the initial push, no merged push (conflicts paused the cycle)
+        assert_eq!(http.push_call_count(), 1);
+    }
+
+    // Initial sync: no credentials → Skipped
+    #[tokio::test]
+    async fn test_initial_sync_no_credentials_skips() {
+        let http = MockHttp404::empty();
+        let client = SyncClient::new(http);
+        let mut clock = VectorClock::new();
+
+        let outcome = client
+            .run_initial_sync(None, b"local", false, &mut clock, &no_op_merge)
+            .await;
+
+        assert_eq!(outcome, SyncOutcome::Skipped);
+    }
+
+    // Initial sync: server unreachable → Offline
+    #[tokio::test]
+    async fn test_initial_sync_offline_returns_offline() {
+        let http = MockHttp::offline();
+        let client = SyncClient::new(http);
+        let mut clock = VectorClock::new();
+
+        let outcome = client
+            .run_initial_sync(Some(&creds()), b"local", false, &mut clock, &no_op_merge)
+            .await;
+
+        assert_eq!(outcome, SyncOutcome::Offline);
     }
 }

--- a/src/sync/vector_clock.rs
+++ b/src/sync/vector_clock.rs
@@ -24,6 +24,11 @@ impl VectorClock {
         Self(HashMap::new())
     }
 
+    /// Returns `true` if the clock has no entries (never been incremented).
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
     /// Return the sequence number for a device, defaulting to 0.
     pub fn get(&self, device_id: &str) -> u64 {
         *self.0.get(device_id).unwrap_or(&0)
@@ -186,6 +191,19 @@ mod tests {
         a.merge(&b);
         assert_eq!(a.get("d1"), 5);
         assert_eq!(a.get("d2"), 7);
+    }
+
+    #[test]
+    fn test_is_empty_on_new_clock() {
+        let c = VectorClock::new();
+        assert!(c.is_empty());
+    }
+
+    #[test]
+    fn test_is_empty_false_after_increment() {
+        let mut c = VectorClock::new();
+        c.increment("dev-a");
+        assert!(!c.is_empty());
     }
 
     #[test]

--- a/tests/e2e/steps/sync_integration.steps.ts
+++ b/tests/e2e/steps/sync_integration.steps.ts
@@ -124,8 +124,13 @@ Then("the sync should complete without errors", async ({ page }) => {
       l.includes("[Sync] Pull for merge failed"),
   );
 
-  // Assert no HTTP errors from sync requests
-  const failedRequests = syncRequests.filter((r) => r.status >= 400);
+  // Assert no HTTP errors from sync requests.
+  // A 404 on /metadata is expected during initial sync (empty server slot) — exclude it.
+  const failedRequests = syncRequests.filter(
+    (r) =>
+      r.status >= 400 &&
+      !(r.status === 404 && r.method === "GET" && r.url.endsWith("/metadata")),
+  );
 
   if (failedRequests.length > 0 || syncErrors.length > 0) {
     const details = [


### PR DESCRIPTION
## Summary

Closes #149

When a device with pre-existing workouts joins a sync group that already has server data, the initial sync previously treated this as a fast-forward pull, silently overwriting local workouts. This PR adds a dedicated initial sync path that inspects the server state *before* deciding the sync strategy, preserving data from both sides via union merge.

### Changes

- **`SyncClient::run_initial_sync`** — new method that probes server metadata (handling 404 as "empty slot") and selects the correct strategy from a 2x2 matrix:

  | Local DB | Server slot | Action |
  |----------|------------|--------|
  | Empty | Empty (404) | No-op |
  | Has data | Empty (404) | Push |
  | Empty | Has data | Pull (fast-forward) |
  | Has data | Has data | Push first, then merge, then push merged result |

- **`trigger_background_sync`** — detects first-ever sync (empty vector clock) and delegates to `run_initial_sync`, checking the exercise list to determine whether the local DB has meaningful data
- **`VectorClock::is_empty()`** — convenience method for the first-sync check

### QA Checklist

(from ralph-assess)

- [ ] A device with pre-existing workouts joins a sync group that already has data from other devices; after initial sync completes, all local workouts are still present on that device
- [ ] After the same initial sync, the server's pre-existing data from other devices is still present and accessible from the joining device
- [ ] The merged result on both server and joining device is the superset (union) of both datasets, with no duplicates lost
- [ ] A device with an empty local DB joins a sync group that has server data; the server data is pulled without triggering an unnecessary conflict or merge cycle
- [ ] A device with local data joins a sync group whose server slot is empty (404); the local data is pushed to the server without triggering an unnecessary conflict or merge cycle
- [ ] A device with an empty local DB joins a sync group with an empty server slot; no sync operations occur (no-op)

## Test plan

- [x] 7 new unit tests covering all four matrix cases plus edge cases (no credentials, conflicts, offline)
- [x] All 137 tests pass (128 existing + 9 new)
- [ ] E2E: pair a device with existing workouts to a group with server data and verify both datasets are present after sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)