### PR TITLE
feat(sync): WebSocket CRR changeset sync via wasm_bindgen bridge

### DIFF
--- a/public/db-module.js
+++ b/public/db-module.js
@@ -25,7 +25,7 @@ let sqlite = null;
 let _syncModulePromise = null;
 async function getSyncModule() {
   if (!_syncModulePromise) {
-    _syncModulePromise = import("/sync-module.js");
+    _syncModulePromise = import("./sync-module.js");
   }
   return _syncModulePromise;
 }

--- a/public/db-module.js
+++ b/public/db-module.js
@@ -21,6 +21,29 @@ const MIGRATION_KEY = "crsqlite_migration_done";
 let db = null;
 let sqlite = null;
 
+// Lazy-import of the sync module. Resolved on first use.
+let _syncModulePromise = null;
+async function getSyncModule() {
+  if (!_syncModulePromise) {
+    _syncModulePromise = import("/sync-module.js");
+  }
+  return _syncModulePromise;
+}
+
+/**
+ * Register the open database handle with the sync module so it can read/write
+ * changesets via crsql_changes().
+ */
+async function registerDbWithSync() {
+  try {
+    const syncMod = await getSyncModule();
+    syncMod.registerSyncDb(db);
+    console.log("[DB] Registered database with sync module");
+  } catch (e) {
+    console.warn("[DB] Failed to register database with sync module:", e);
+  }
+}
+
 /**
  * Initialise the crsqlite-wasm module (singleton).
  */
@@ -81,6 +104,10 @@ export async function initDatabase(fileData) {
     // Safe to run every launch — crsql_as_crr is a no-op on tables that are
     // already CRRs.
     await applyCrrMigration();
+
+    // Register the open DB handle with the sync module so WebSocket sync
+    // can access crsql_changes().
+    await registerDbWithSync();
 
     // Expose a raw SQL hook for the Playwright test harness.
     if (typeof window !== "undefined" && window.__TEST_MODE__) {
@@ -298,6 +325,9 @@ export async function importDatabase(fileData) {
 
     // Re-apply CRR upgrade on the freshly imported data.
     await applyCrrMigration();
+
+    // Re-register with sync module after import.
+    await registerDbWithSync();
 
     return true;
   } catch (error) {

--- a/public/sync-module.js
+++ b/public/sync-module.js
@@ -1,0 +1,348 @@
+// WebSocket-based CRR changeset sync module.
+//
+// Uses the crsql_changes() virtual table provided by crsqlite-wasm to extract
+// and apply changesets.  Communicates with the sync server over a WebSocket
+// connection (one per sync cycle).
+//
+// This module is called from Rust via wasm_bindgen FFI (see src/sync/ws_bridge.rs).
+// Sync results are communicated back to Rust through resolved promises.
+
+// Lazily-resolved reference to the live crsqlite DB handle.
+// The db-module.js initDatabase() stores the open handle on this module-level
+// variable via registerSyncDb().
+let _db = null;
+
+/**
+ * Register the live crsqlite database handle for use by the sync module.
+ * Called by db-module.js after the database is opened.
+ *
+ * @param {object} db  The crsqlite-wasm DB instance.
+ */
+export function registerSyncDb(db) {
+  _db = db;
+}
+
+function getDb() {
+  if (!_db) {
+    throw new Error("[Sync] Database not registered with sync module. Call registerSyncDb() first.");
+  }
+  return _db;
+}
+
+/**
+ * Get the current db_version (site's latest change version).
+ * Used to determine which changes to send.
+ *
+ * @returns {Promise<bigint>} The current db_version.
+ */
+async function getDbVersion() {
+  const db = getDb();
+  const rows = await db.execA("SELECT crsql_db_version()");
+  if (rows && rows.length > 0) {
+    return BigInt(rows[0][0]);
+  }
+  return 0n;
+}
+
+/**
+ * Get the site_id for this database instance (a unique 16-byte identifier).
+ *
+ * @returns {Promise<Uint8Array>} The site_id bytes.
+ */
+async function getSiteId() {
+  const db = getDb();
+  const rows = await db.execA("SELECT crsql_site_id()");
+  if (rows && rows.length > 0) {
+    return rows[0][0];
+  }
+  throw new Error("[Sync] Could not read crsql_site_id()");
+}
+
+/**
+ * Extract local changesets since the given version.
+ *
+ * The crsql_changes() virtual table returns rows with columns:
+ *   [table, pk, cid, val, col_version, db_version, site_id, cl, seq]
+ *
+ * @param {bigint} sinceVersion  Only return changes with db_version > sinceVersion.
+ * @returns {Promise<Array>} Array of change rows.
+ */
+async function getChangesSince(sinceVersion) {
+  const db = getDb();
+  const rows = await db.execA(
+    "SELECT [table], [pk], [cid], [val], [col_version], [db_version], [site_id], [cl], [seq] " +
+    "FROM crsql_changes WHERE db_version > ?",
+    [sinceVersion]
+  );
+  return rows || [];
+}
+
+/**
+ * Apply remote changesets received from the server.
+ *
+ * Each change is inserted into crsql_changes() which handles CRDT merge logic.
+ *
+ * @param {Array<Array>} changes  Array of change rows (same column order as getChangesSince).
+ */
+async function applyChanges(changes) {
+  if (!changes || changes.length === 0) return;
+
+  const db = getDb();
+  await db.exec("BEGIN");
+  try {
+    for (const change of changes) {
+      await db.exec(
+        "INSERT INTO crsql_changes ([table], [pk], [cid], [val], [col_version], [db_version], [site_id], [cl], [seq]) " +
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        change
+      );
+    }
+    await db.exec("COMMIT");
+  } catch (e) {
+    await db.exec("ROLLBACK");
+    throw e;
+  }
+}
+
+/**
+ * Encode changesets as JSON for WebSocket transmission.
+ * BigInt values are converted to strings for JSON compatibility.
+ *
+ * @param {Array<Array>} changes  Change rows from getChangesSince.
+ * @returns {string} JSON-encoded changes.
+ */
+function encodeChanges(changes) {
+  return JSON.stringify(changes, (_key, value) =>
+    typeof value === "bigint" ? value.toString() : value
+  );
+}
+
+/**
+ * Build the WebSocket URL from the HTTP sync base URL and sync_id.
+ *
+ * @param {string} syncId  The sync slot identifier.
+ * @returns {string} WebSocket URL.
+ */
+function buildWsUrl(syncId) {
+  // Read the sync base URL (injected at build time).
+  let base = window.SYNC_BASE_URL || "";
+  if (!base || base.includes("%%")) {
+    // Fallback: derive from current page origin.
+    base = window.location.origin + "/api";
+  }
+
+  // Convert http(s) to ws(s).
+  const wsBase = base.replace(/^http/, "ws");
+  return `${wsBase.replace(/\/$/, "")}/sync/${syncId}/ws`;
+}
+
+// ── Sync-state tracking ───────────────────────────────────────────────────────
+// The server tracks the last db_version it has seen from each client.  On the
+// client side we persist the "last version we sent" in localStorage so we only
+// send new changesets on each sync cycle.
+
+const LAST_SENT_KEY = "sync_last_sent_version";
+
+function getLastSentVersion() {
+  try {
+    const raw = localStorage.getItem(LAST_SENT_KEY);
+    return raw ? BigInt(raw) : 0n;
+  } catch {
+    return 0n;
+  }
+}
+
+function setLastSentVersion(version) {
+  try {
+    localStorage.setItem(LAST_SENT_KEY, version.toString());
+  } catch {
+    // localStorage may be unavailable in some contexts; ignore.
+  }
+}
+
+// Track the last version we received from the server so we can tell the
+// server which changes to send us.
+const LAST_RECEIVED_KEY = "sync_last_received_version";
+
+function getLastReceivedVersion() {
+  try {
+    const raw = localStorage.getItem(LAST_RECEIVED_KEY);
+    return raw ? BigInt(raw) : 0n;
+  } catch {
+    return 0n;
+  }
+}
+
+function setLastReceivedVersion(version) {
+  try {
+    localStorage.setItem(LAST_RECEIVED_KEY, version.toString());
+  } catch {
+    // Ignore.
+  }
+}
+
+/**
+ * Run one sync cycle over WebSocket.
+ *
+ * Protocol:
+ *   1. Client opens a WebSocket to /sync/:sync_id/ws
+ *   2. Client sends: { type: "push", site_id, changes, last_received_version }
+ *   3. Server responds: { type: "pull", changes }
+ *   4. Client applies received changes, sends: { type: "ack" }
+ *   5. Server sends: { type: "done" } — connection closes.
+ *
+ * @param {string} syncId       The sync slot identifier.
+ * @param {string} syncSecret   Auth secret (sent as first message for auth).
+ * @param {number} timeoutMs    Max time to wait for the sync cycle (default 15s).
+ * @returns {Promise<string>}   Outcome: "synced" | "no_changes" | "offline" | "error:<msg>"
+ */
+export async function runSyncCycle(syncId, syncSecret, timeoutMs = 15000) {
+  try {
+    getDb(); // Validate DB is registered before proceeding.
+    const siteId = await getSiteId();
+
+    // Determine what to send.
+    const lastSent = getLastSentVersion();
+    const localChanges = await getChangesSince(lastSent);
+    const lastReceived = getLastReceivedVersion();
+
+    const wsUrl = buildWsUrl(syncId);
+    console.log(`[Sync] Opening WebSocket to ${wsUrl}`);
+
+    return await new Promise((resolve) => {
+      let settled = false;
+      const timer = setTimeout(() => {
+        if (!settled) {
+          settled = true;
+          try { ws.close(); } catch { /* ignore */ }
+          resolve("offline");
+        }
+      }, timeoutMs);
+
+      let ws;
+      try {
+        ws = new WebSocket(wsUrl);
+      } catch (e) {
+        clearTimeout(timer);
+        console.warn("[Sync] WebSocket constructor failed:", e);
+        resolve("offline");
+        return;
+      }
+
+      ws.onopen = () => {
+        console.log("[Sync] WebSocket connected");
+        // Send auth + changes in one message.
+        const payload = {
+          type: "push",
+          sync_secret: syncSecret,
+          site_id: Array.from(siteId instanceof Uint8Array ? siteId : []),
+          changes: JSON.parse(encodeChanges(localChanges)),
+          last_received_version: lastReceived.toString(),
+        };
+        ws.send(JSON.stringify(payload));
+      };
+
+      ws.onmessage = async (event) => {
+        try {
+          const msg = JSON.parse(event.data);
+
+          if (msg.type === "pull") {
+            // Apply remote changes.
+            const remoteChanges = msg.changes || [];
+            if (remoteChanges.length > 0) {
+              console.log(`[Sync] Applying ${remoteChanges.length} remote changes`);
+              await applyChanges(remoteChanges);
+
+              // Update last-received version from the server's report.
+              if (msg.server_db_version) {
+                setLastReceivedVersion(BigInt(msg.server_db_version));
+              }
+            }
+
+            // Update last-sent version now that the server has our changes.
+            const currentVersion = await getDbVersion();
+            setLastSentVersion(currentVersion);
+
+            // Acknowledge.
+            ws.send(JSON.stringify({ type: "ack" }));
+          } else if (msg.type === "done") {
+            clearTimeout(timer);
+            if (!settled) {
+              settled = true;
+              ws.close();
+              const hadChanges =
+                localChanges.length > 0 ||
+                (msg.applied_count && msg.applied_count > 0);
+              resolve(hadChanges ? "synced" : "no_changes");
+            }
+          } else if (msg.type === "error") {
+            clearTimeout(timer);
+            if (!settled) {
+              settled = true;
+              ws.close();
+              resolve(`error:${msg.message || "unknown"}`);
+            }
+          }
+        } catch (e) {
+          console.error("[Sync] Error processing message:", e);
+          clearTimeout(timer);
+          if (!settled) {
+            settled = true;
+            try { ws.close(); } catch { /* ignore */ }
+            resolve(`error:${e.message || "parse error"}`);
+          }
+        }
+      };
+
+      ws.onerror = (event) => {
+        console.warn("[Sync] WebSocket error:", event);
+        clearTimeout(timer);
+        if (!settled) {
+          settled = true;
+          resolve("offline");
+        }
+      };
+
+      ws.onclose = (event) => {
+        clearTimeout(timer);
+        if (!settled) {
+          settled = true;
+          if (event.code === 1000 || event.code === 1005) {
+            resolve("no_changes");
+          } else {
+            resolve("offline");
+          }
+        }
+      };
+    });
+  } catch (e) {
+    console.error("[Sync] runSyncCycle failed:", e);
+    return `error:${e.message || "unknown"}`;
+  }
+}
+
+/**
+ * Check whether the sync server is reachable (lightweight HTTP health check).
+ * Falls back to "offline" on any error.
+ *
+ * @param {string} syncId  The sync slot identifier.
+ * @returns {Promise<boolean>} true if the server responded.
+ */
+export async function checkSyncServerHealth(syncId) {
+  try {
+    let base = window.SYNC_BASE_URL || "";
+    if (!base || base.includes("%%")) {
+      base = window.location.origin + "/api";
+    }
+    const url = `${base.replace(/\/$/, "")}/sync/${syncId}/metadata`;
+    const resp = await fetch(url, {
+      method: "GET",
+      mode: "cors",
+      signal: AbortSignal.timeout(5000),
+    });
+    // 404 is fine — means the slot doesn't exist yet but the server is up.
+    return resp.ok || resp.status === 404;
+  } catch {
+    return false;
+  }
+}

--- a/src/state/workout_state.rs
+++ b/src/state/workout_state.rs
@@ -710,11 +710,8 @@ impl WorkoutStateManager {
 
         state.set_sync_status(SyncStatus::Syncing);
 
-        let outcome = ws_bridge::run_ws_sync(
-            &credentials.sync_id,
-            &credentials.sync_secret,
-        )
-        .await;
+        let outcome =
+            ws_bridge::run_ws_sync(&credentials.sync_id, &credentials.sync_secret).await;
 
         match outcome {
             crate::sync::WsSyncOutcome::Synced => {
@@ -733,9 +730,7 @@ impl WorkoutStateManager {
             }
             crate::sync::WsSyncOutcome::Offline => {
                 log::warn!("[Sync] Server unreachable — continuing offline");
-                state.set_sync_status(SyncStatus::Error(
-                    "Server unreachable".to_string(),
-                ));
+                state.set_sync_status(SyncStatus::Error("Server unreachable".to_string()));
             }
             crate::sync::WsSyncOutcome::Error(msg) => {
                 log::warn!("[Sync] Sync error: {}", msg);

--- a/src/state/workout_state.rs
+++ b/src/state/workout_state.rs
@@ -710,8 +710,7 @@ impl WorkoutStateManager {
 
         state.set_sync_status(SyncStatus::Syncing);
 
-        let outcome =
-            ws_bridge::run_ws_sync(&credentials.sync_id, &credentials.sync_secret).await;
+        let outcome = ws_bridge::run_ws_sync(&credentials.sync_id, &credentials.sync_secret).await;
 
         match outcome {
             crate::sync::WsSyncOutcome::Synced => {

--- a/src/state/workout_state.rs
+++ b/src/state/workout_state.rs
@@ -688,13 +688,15 @@ impl WorkoutStateManager {
         }
     }
 
-    /// Trigger a background sync cycle.  Non-blocking: errors are swallowed
-    /// except for `ConflictDetected`, which surfaces the conflict resolution UI.
+    /// Trigger a background sync cycle using WebSocket-based CRR changeset
+    /// exchange.  Non-blocking: errors are logged but do not crash the app.
     ///
     /// This is a no-op when `sync_id` is not configured in LocalStorage
     /// (i.e. the pairing flow has not been run yet).
     #[cfg(not(test))]
     pub async fn trigger_background_sync(state: &WorkoutState) {
+        use crate::sync::ws_bridge;
+
         // Load existing credentials. If none are saved, sync is not configured
         // and we skip silently — the user must explicitly set up sync first.
         let Some(credentials) = SyncCredentials::load() else {
@@ -706,24 +708,40 @@ impl WorkoutStateManager {
             return;
         }
 
-        // Sync is disabled: the old blob-level protocol is incompatible with
-        // the new CRR-backed database.  Rather than silently running no-op
-        // network calls, we short-circuit here and surface the state to the
-        // user.  Remove this gate once CRR changeset exchange is implemented.
-        let _ = credentials; // validated above; will be used by CRR sync
-        log::info!(
-            "[Sync] Sync is temporarily disabled while the protocol is migrated to CRR changesets"
-        );
-        state.set_sync_status(SyncStatus::Disabled(
-            "Sync is temporarily unavailable — update in progress".to_string(),
-        ));
-        // TODO(sync): Once CRR changeset exchange is implemented, replace this
-        // early return with:
-        // 1. Extract local changesets via `crsql_changes()`
-        // 2. Send changesets to server via SyncClient
-        // 3. Apply server changesets locally
-        // 4. Update vector clock and sync status
-        // See git history for the previous blob-level sync implementation.
+        state.set_sync_status(SyncStatus::Syncing);
+
+        let outcome = ws_bridge::run_ws_sync(
+            &credentials.sync_id,
+            &credentials.sync_secret,
+        )
+        .await;
+
+        match outcome {
+            crate::sync::WsSyncOutcome::Synced => {
+                log::info!("[Sync] CRR changeset sync completed — changes exchanged");
+                state.set_sync_status(SyncStatus::UpToDate);
+
+                // Re-read exercises from the database since remote changes may
+                // have added or modified exercise rows.
+                if let Err(e) = Self::sync_exercises(state).await {
+                    log::warn!("[Sync] Failed to refresh exercises after sync: {}", e);
+                }
+            }
+            crate::sync::WsSyncOutcome::NoChanges => {
+                log::debug!("[Sync] CRR changeset sync — no changes to exchange");
+                state.set_sync_status(SyncStatus::UpToDate);
+            }
+            crate::sync::WsSyncOutcome::Offline => {
+                log::warn!("[Sync] Server unreachable — continuing offline");
+                state.set_sync_status(SyncStatus::Error(
+                    "Server unreachable".to_string(),
+                ));
+            }
+            crate::sync::WsSyncOutcome::Error(msg) => {
+                log::warn!("[Sync] Sync error: {}", msg);
+                state.set_sync_status(SyncStatus::Error(msg));
+            }
+        }
     }
 
     /// Shared helper for `Pulled` and `Merged` sync outcomes: initialise a new

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -1,6 +1,7 @@
 pub mod client;
 pub mod credentials;
 pub mod vector_clock;
+pub mod ws_bridge;
 
 #[cfg(not(test))]
 pub mod http;
@@ -8,6 +9,7 @@ pub mod http;
 pub use client::{ConflictRecord, MergeResult, SyncClient, SyncOutcome};
 pub use credentials::{SyncCredentials, delete_clock, load_clock, save_clock};
 pub use vector_clock::VectorClock;
+pub use ws_bridge::WsSyncOutcome;
 
 /// Trivial merge stub for tests. Returns the local blob unchanged.
 #[cfg(test)]

--- a/src/sync/ws_bridge.rs
+++ b/src/sync/ws_bridge.rs
@@ -1,0 +1,149 @@
+/// WebSocket-based CRR changeset sync bridge.
+///
+/// This module provides the Rust-to-JS FFI layer for the new vlcn.io/crsqlite
+/// WebSocket sync protocol.  It imports functions from `sync-module.js` via
+/// `wasm_bindgen` and exposes a high-level `run_ws_sync()` function that
+/// `trigger_background_sync()` calls.
+///
+/// The JS module handles:
+///   - Opening a WebSocket connection to the sync server
+///   - Extracting local changesets via `crsql_changes()`
+///   - Sending changesets and applying received ones
+///   - Closing the connection after the exchange
+///
+/// This Rust module handles:
+///   - Calling the JS sync function with credentials
+///   - Interpreting the result string into a `WsSyncOutcome`
+///   - Logging and error handling
+
+// ── JS FFI bindings (WASM-only) ─────────────────────────────────────────────
+
+#[cfg(not(test))]
+mod ffi {
+    use wasm_bindgen::prelude::*;
+
+    #[wasm_bindgen(module = "/public/sync-module.js")]
+    extern "C" {
+        /// Run one WebSocket sync cycle.
+        ///
+        /// Returns a promise that resolves to a string:
+        ///   "synced"       — changes were exchanged successfully
+        ///   "no_changes"   — connected but nothing to sync
+        ///   "offline"      — could not connect to the server
+        ///   "error:<msg>"  — an error occurred
+        #[wasm_bindgen(js_name = runSyncCycle)]
+        pub async fn run_sync_cycle_js(
+            sync_id: &str,
+            sync_secret: &str,
+            timeout_ms: u32,
+        ) -> JsValue;
+
+        /// Check whether the sync server is reachable.
+        #[wasm_bindgen(js_name = checkSyncServerHealth)]
+        pub async fn check_sync_server_health_js(sync_id: &str) -> JsValue;
+    }
+}
+
+// ── Outcome type ─────────────────────────────────────────────────────────────
+
+/// Result of a single WebSocket sync cycle.
+#[derive(Debug, Clone, PartialEq)]
+pub enum WsSyncOutcome {
+    /// Changes were exchanged with the server.
+    Synced,
+    /// Connected successfully but there were no changes to exchange.
+    NoChanges,
+    /// Server was unreachable (network error, timeout, etc.).
+    Offline,
+    /// An error occurred during the sync cycle.
+    Error(String),
+}
+
+// ── Public API (WASM-only) ───────────────────────────────────────────────────
+
+/// Default timeout for a single sync cycle (15 seconds).
+#[cfg(not(test))]
+const SYNC_TIMEOUT_MS: u32 = 15_000;
+
+/// Run one WebSocket-based CRR changeset sync cycle.
+///
+/// This is the main entry point called by `trigger_background_sync()`.
+/// It delegates to the JS sync module which manages the WebSocket connection
+/// and changeset exchange.
+#[cfg(not(test))]
+pub async fn run_ws_sync(sync_id: &str, sync_secret: &str) -> WsSyncOutcome {
+    log::debug!("[WS Sync] Starting sync cycle for slot {}", sync_id);
+
+    let result = ffi::run_sync_cycle_js(sync_id, sync_secret, SYNC_TIMEOUT_MS).await;
+
+    let outcome_str = result.as_string().unwrap_or_else(|| "error:unknown".to_string());
+
+    let outcome = parse_outcome(&outcome_str);
+
+    match &outcome {
+        WsSyncOutcome::Synced => log::info!("[WS Sync] Sync completed — changes exchanged"),
+        WsSyncOutcome::NoChanges => log::debug!("[WS Sync] Sync completed — no changes"),
+        WsSyncOutcome::Offline => log::warn!("[WS Sync] Server unreachable"),
+        WsSyncOutcome::Error(msg) => log::warn!("[WS Sync] Error: {}", msg),
+    }
+
+    outcome
+}
+
+/// Check whether the sync server is reachable.
+#[cfg(not(test))]
+pub async fn is_server_reachable(sync_id: &str) -> bool {
+    let result = ffi::check_sync_server_health_js(sync_id).await;
+    result.as_bool().unwrap_or(false)
+}
+
+// ── Pure logic (available in tests) ──────────────────────────────────────────
+
+/// Parse the outcome string returned by the JS sync module.
+pub fn parse_outcome(s: &str) -> WsSyncOutcome {
+    match s {
+        "synced" => WsSyncOutcome::Synced,
+        "no_changes" => WsSyncOutcome::NoChanges,
+        "offline" => WsSyncOutcome::Offline,
+        other if other.starts_with("error:") => {
+            WsSyncOutcome::Error(other[6..].to_string())
+        }
+        other => WsSyncOutcome::Error(format!("unexpected outcome: {}", other)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_outcome_synced() {
+        assert_eq!(parse_outcome("synced"), WsSyncOutcome::Synced);
+    }
+
+    #[test]
+    fn test_parse_outcome_no_changes() {
+        assert_eq!(parse_outcome("no_changes"), WsSyncOutcome::NoChanges);
+    }
+
+    #[test]
+    fn test_parse_outcome_offline() {
+        assert_eq!(parse_outcome("offline"), WsSyncOutcome::Offline);
+    }
+
+    #[test]
+    fn test_parse_outcome_error() {
+        assert_eq!(
+            parse_outcome("error:connection refused"),
+            WsSyncOutcome::Error("connection refused".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_outcome_unknown() {
+        assert_eq!(
+            parse_outcome("garbage"),
+            WsSyncOutcome::Error("unexpected outcome: garbage".to_string())
+        );
+    }
+}

--- a/src/sync/ws_bridge.rs
+++ b/src/sync/ws_bridge.rs
@@ -76,7 +76,9 @@ pub async fn run_ws_sync(sync_id: &str, sync_secret: &str) -> WsSyncOutcome {
 
     let result = ffi::run_sync_cycle_js(sync_id, sync_secret, SYNC_TIMEOUT_MS).await;
 
-    let outcome_str = result.as_string().unwrap_or_else(|| "error:unknown".to_string());
+    let outcome_str = result
+        .as_string()
+        .unwrap_or_else(|| "error:unknown".to_string());
 
     let outcome = parse_outcome(&outcome_str);
 
@@ -105,9 +107,7 @@ pub fn parse_outcome(s: &str) -> WsSyncOutcome {
         "synced" => WsSyncOutcome::Synced,
         "no_changes" => WsSyncOutcome::NoChanges,
         "offline" => WsSyncOutcome::Offline,
-        other if other.starts_with("error:") => {
-            WsSyncOutcome::Error(other[6..].to_string())
-        }
+        other if other.starts_with("error:") => WsSyncOutcome::Error(other[6..].to_string()),
         other => WsSyncOutcome::Error(format!("unexpected outcome: {}", other)),
     }
 }

--- a/src/sync/ws_bridge.rs
+++ b/src/sync/ws_bridge.rs
@@ -1,20 +1,20 @@
-/// WebSocket-based CRR changeset sync bridge.
-///
-/// This module provides the Rust-to-JS FFI layer for the new vlcn.io/crsqlite
-/// WebSocket sync protocol.  It imports functions from `sync-module.js` via
-/// `wasm_bindgen` and exposes a high-level `run_ws_sync()` function that
-/// `trigger_background_sync()` calls.
-///
-/// The JS module handles:
-///   - Opening a WebSocket connection to the sync server
-///   - Extracting local changesets via `crsql_changes()`
-///   - Sending changesets and applying received ones
-///   - Closing the connection after the exchange
-///
-/// This Rust module handles:
-///   - Calling the JS sync function with credentials
-///   - Interpreting the result string into a `WsSyncOutcome`
-///   - Logging and error handling
+// WebSocket-based CRR changeset sync bridge.
+//
+// This module provides the Rust-to-JS FFI layer for the new vlcn.io/crsqlite
+// WebSocket sync protocol.  It imports functions from `sync-module.js` via
+// `wasm_bindgen` and exposes a high-level `run_ws_sync()` function that
+// `trigger_background_sync()` calls.
+//
+// The JS module handles:
+//   - Opening a WebSocket connection to the sync server
+//   - Extracting local changesets via `crsql_changes()`
+//   - Sending changesets and applying received ones
+//   - Closing the connection after the exchange
+//
+// This Rust module handles:
+//   - Calling the JS sync function with credentials
+//   - Interpreting the result string into a `WsSyncOutcome`
+//   - Logging and error handling
 
 // ── JS FFI bindings (WASM-only) ─────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Adds `public/sync-module.js`: JS glue layer that opens a WebSocket to the sync server, extracts local CRR changesets via `crsql_changes()`, sends them, applies received remote changesets, and returns a typed outcome string
- Adds `src/sync/ws_bridge.rs`: Rust FFI bridge importing the JS module via `wasm_bindgen`, exposing `run_ws_sync()` with a `WsSyncOutcome` enum
- Rewires `trigger_background_sync()` from the disabled stub to the new WebSocket bridge, with proper `SyncStatus` signal updates and exercise refresh after successful sync
- Registers the crsqlite DB handle with the sync module after `initDatabase()` and `importDatabase()`

## Test plan

- [ ] `cargo test` passes (5 new `parse_outcome` unit tests in `ws_bridge`)
- [ ] Existing 145 tests unaffected
- [ ] Two paired devices sync exercises via WebSocket (manual E2E)
- [ ] Offline → reconnect triggers sync automatically
- [ ] Status indicator transitions: synced → offline → syncing → synced

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)