### PR TITLE
fix(sync): correct WebSocket URL path and wire protocol for vlcn.io server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "AGPLv3"
 
 [dependencies]
 dioxus = { version = "0.7.3", features = ["web", "router"] }
-wasm-bindgen = "=0.2.114"
+wasm-bindgen = "=0.2.117"
 wasm-bindgen-futures = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,8 +4,7 @@ import { defineBddConfig } from "playwright-bdd";
 // Tag convention: every .feature file must have either @fast or @e2e.
 // @fast → runs in playwright.fast.config.ts against a local dx serve.
 // @e2e → runs here against the Vercel preview URL.
-// @sync-backend → requires live sync backend; excluded from CI by default.
-//   Run manually: SYNC_BACKEND=1 npx playwright test --config playwright.config.ts
+// @sync-backend → requires live sync backend (always included in CI).
 // An untagged feature file will be silently excluded from both suites.
 const testDir = defineBddConfig({
   features: "tests/e2e/features/**/*.feature",

--- a/public/db-module.js
+++ b/public/db-module.js
@@ -64,6 +64,27 @@ async function ensureCrSQLiteLoaded() {
  *   migrated into the new crsqlite DB on first launch.
  * @returns {Promise<boolean>} true on success.
  */
+/**
+ * Re-run the CRR migration.  Called from Rust after schema tables have been
+ * created so that tables that didn't exist during initDatabase() are still
+ * marked as CRRs.
+ *
+ * @returns {Promise<boolean>} true on success.
+ */
+export async function ensureCrrTables() {
+  try {
+    if (!db) return false;
+    await applyCrrMigration();
+    // Re-register db with sync module after CRR marking to ensure the
+    // sync module's handle reflects the post-CRR state.
+    await registerDbWithSync();
+    return true;
+  } catch (e) {
+    console.warn("[DB] ensureCrrTables failed:", e);
+    return false;
+  }
+}
+
 export async function initDatabase(fileData) {
   try {
     await ensureCrSQLiteLoaded();

--- a/public/sync-module.js
+++ b/public/sync-module.js
@@ -1,11 +1,371 @@
-// WebSocket-based CRR changeset sync module.
+// Module-level singletons to avoid constructing in hot paths.
+const _textEncoder = new TextEncoder();
+const _textDecoder = new TextDecoder();
+
+// Schema identity — must match sync-backend/schemas/default via cryb64 hash.
+const SCHEMA_NAME = "default";
+const SCHEMA_VERSION = 589454654283815490n;
+
+// WebSocket-based CRR changeset sync module using the vlcn.io binary wire protocol.
 //
 // Uses the crsql_changes() virtual table provided by crsqlite-wasm to extract
-// and apply changesets.  Communicates with the sync server over a WebSocket
-// connection (one per sync cycle).
+// and apply changesets.  Communicates with the sync server (powered by
+// @vlcn.io/ws-server) over a WebSocket connection (one per sync cycle).
+//
+// The server expects:
+//   - URL path: /sync/<sync_id> (no /ws suffix)
+//   - Room metadata in sec-websocket-protocol header (base64-encoded)
+//   - Binary wire format using lib0-compatible encoding (@vlcn.io/ws-common)
+//
+// Protocol flow:
+//   1. Client sends AnnouncePresence (tag=1) with site_id and lastSeens
+//   2. Server sends Changes (tag=2) or StartStreaming (tag=4)
+//   3. Client sends Changes (tag=2) with local changesets
 //
 // This module is called from Rust via wasm_bindgen FFI (see src/sync/ws_bridge.rs).
 // Sync results are communicated back to Rust through resolved promises.
+
+// ── lib0-compatible binary encoder/decoder ────────────────────────────────────
+// Minimal implementation of the lib0 encoding used by @vlcn.io/ws-common.
+
+function createEncoder() {
+  return { bufs: [], len: 0 };
+}
+
+function _push(enc, bytes) {
+  enc.bufs.push(bytes);
+  enc.len += bytes.length;
+}
+
+function writeUint8(enc, val) {
+  _push(enc, new Uint8Array([val & 0xff]));
+}
+
+function writeVarUint(enc, val) {
+  while (val > 0x7f) {
+    _push(enc, new Uint8Array([(val & 0x7f) | 0x80]));
+    val = Math.floor(val / 128);
+  }
+  _push(enc, new Uint8Array([val & 0x7f]));
+}
+
+function writeVarInt(enc, val) {
+  const isNeg = val < 0;
+  if (isNeg) val = -val;
+  _push(enc, new Uint8Array([((val > 0x3f ? 0x80 : 0) | (isNeg ? 0x40 : 0) | (val & 0x3f))]));
+  val = Math.floor(val / 64);
+  while (val > 0) {
+    _push(enc, new Uint8Array([(val > 0x7f ? 0x80 : 0) | (val & 0x7f)]));
+    val = Math.floor(val / 128);
+  }
+}
+
+function writeBigInt64(enc, val) {
+  const buf = new ArrayBuffer(8);
+  // lib0 uses big-endian for BigInt64. Handle unsigned values > 2^63 by
+  // wrapping to the signed representation (same bit pattern).
+  let signed = BigInt(val);
+  if (signed >= (1n << 63n)) signed -= (1n << 64n);
+  new DataView(buf).setBigInt64(0, signed, false); // big-endian, matching lib0
+  _push(enc, new Uint8Array(buf));
+}
+
+function writeFloat64(enc, val) {
+  const buf = new ArrayBuffer(8);
+  new DataView(buf).setFloat64(0, val, false);
+  _push(enc, new Uint8Array(buf));
+}
+
+function writeVarString(enc, str) {
+  const bytes = _textEncoder.encode(str);
+  writeVarUint(enc, bytes.length);
+  _push(enc, bytes);
+}
+
+function writeUint8Array(enc, arr) {
+  _push(enc, new Uint8Array(arr));
+}
+
+function writeVarUint8Array(enc, arr) {
+  writeVarUint(enc, arr.length);
+  _push(enc, new Uint8Array(arr));
+}
+
+function toUint8Array(enc) {
+  const result = new Uint8Array(enc.len);
+  let offset = 0;
+  for (const buf of enc.bufs) {
+    result.set(buf, offset);
+    offset += buf.length;
+  }
+  return result;
+}
+
+// ── Decoder ──
+
+function createDecoder(data) {
+  return { data: new Uint8Array(data), pos: 0 };
+}
+
+function readUint8(dec) {
+  if (dec.pos >= dec.data.length) throw new Error('[Sync] Decoder overrun');
+  return dec.data[dec.pos++];
+}
+
+function readVarUint(dec) {
+  // Use multiplication instead of bitwise OR to avoid 32-bit overflow.
+  let val = 0;
+  let mult = 1;
+  while (true) {
+    const b = dec.data[dec.pos++];
+    val += (b & 0x7f) * mult;
+    if (b < 0x80) break;
+    mult *= 128;
+  }
+  return val;
+}
+
+function readVarInt(dec) {
+  const first = dec.data[dec.pos++];
+  const isNeg = (first & 0x40) !== 0;
+  let val = first & 0x3f;
+  let mult = 64;
+  if (first & 0x80) {
+    while (true) {
+      const b = dec.data[dec.pos++];
+      val += (b & 0x7f) * mult;
+      mult *= 128;
+      if (b < 0x80) break;
+    }
+  }
+  return isNeg ? -val : val;
+}
+
+function readBigInt64(dec) {
+  const view = new DataView(dec.data.buffer, dec.data.byteOffset + dec.pos, 8);
+  dec.pos += 8;
+  return view.getBigInt64(0, false); // big-endian, matching lib0
+}
+
+function readFloat64(dec) {
+  const view = new DataView(dec.data.buffer, dec.data.byteOffset + dec.pos, 8);
+  dec.pos += 8;
+  return view.getFloat64(0, false);
+}
+
+function readVarString(dec) {
+  const len = readVarUint(dec);
+  const bytes = dec.data.slice(dec.pos, dec.pos + len);
+  dec.pos += len;
+  return _textDecoder.decode(bytes);
+}
+
+function readUint8ArrayFixed(dec, len) {
+  const arr = dec.data.slice(dec.pos, dec.pos + len);
+  dec.pos += len;
+  return arr;
+}
+
+function readVarUint8Array(dec) {
+  const len = readVarUint(dec);
+  const arr = dec.data.slice(dec.pos, dec.pos + len);
+  dec.pos += len;
+  return arr;
+}
+
+// hasMoreData removed — not needed for current message decoding.
+
+// ── Message tags (from @vlcn.io/ws-common) ────────────────────────────────────
+
+const Tag = {
+  AnnouncePresence: 1,
+  Changes: 2,
+  RejectChanges: 3,
+  StartStreaming: 4,
+  Ping: 7,
+  Pong: 8,
+};
+
+// ── Value type tags for encoding change values ────────────────────────────────
+
+const ValType = {
+  NULL: 0,
+  BIGINT: 1,
+  NUMBER: 2,
+  STRING: 3,
+  BOOL: 4,
+  BLOB: 5,
+};
+
+// ── Protocol message encoding ─────────────────────────────────────────────────
+
+/**
+ * Encode an AnnouncePresence message (tag=1).
+ *
+ * @param {Uint8Array} siteId   16-byte site identifier from crsql_site_id().
+ * @param {Array}      lastSeens Array of [siteId(Uint8Array), [version(bigint), seq(number)]].
+ * @returns {Uint8Array} Binary-encoded message.
+ */
+function encodeAnnouncePresence(siteId, lastSeens) {
+  const enc = createEncoder();
+  writeUint8(enc, Tag.AnnouncePresence);
+  // sender (16 bytes, fixed)
+  writeUint8Array(enc, siteId);
+  // lastSeens count
+  writeVarUint(enc, lastSeens.length);
+  for (const [sid, [version, seq]] of lastSeens) {
+    writeUint8Array(enc, sid); // 16 bytes
+    writeBigInt64(enc, version);
+    writeVarInt(enc, seq);
+  }
+  // schemaName
+  writeVarString(enc, SCHEMA_NAME);
+  // schemaVersion
+  writeBigInt64(enc, SCHEMA_VERSION);
+  return toUint8Array(enc);
+}
+
+/**
+ * Write a typed value to the encoder, prefixed with its type tag.
+ */
+function writeTypedValue(enc, val) {
+  if (val === null || val === undefined) {
+    writeUint8(enc, ValType.NULL);
+  } else if (typeof val === "bigint") {
+    writeUint8(enc, ValType.BIGINT);
+    writeBigInt64(enc, val);
+  } else if (typeof val === "number") {
+    writeUint8(enc, ValType.NUMBER);
+    writeFloat64(enc, val);
+  } else if (typeof val === "string") {
+    writeUint8(enc, ValType.STRING);
+    writeVarString(enc, val);
+  } else if (typeof val === "boolean") {
+    writeUint8(enc, ValType.BOOL);
+    writeUint8(enc, val ? 1 : 0);
+  } else if (val instanceof Uint8Array) {
+    writeUint8(enc, ValType.BLOB);
+    writeVarUint8Array(enc, val);
+  } else {
+    // Fallback: coerce to string
+    writeUint8(enc, ValType.STRING);
+    writeVarString(enc, String(val));
+  }
+}
+
+/**
+ * Read a typed value from the decoder.
+ */
+function readTypedValue(dec) {
+  const type = readUint8(dec);
+  switch (type) {
+    case ValType.NULL: return null;
+    case ValType.BIGINT: return readBigInt64(dec);
+    case ValType.NUMBER: return readFloat64(dec);
+    case ValType.STRING: return readVarString(dec);
+    case ValType.BOOL: return readUint8(dec) !== 0;
+    case ValType.BLOB: return readVarUint8Array(dec);
+    default: throw new Error(`[Sync] Unknown value type tag: ${type}`);
+  }
+}
+
+/**
+ * Encode a Changes message (tag=2).
+ *
+ * @param {Uint8Array} siteId  16-byte site identifier.
+ * @param {bigint}     since   The db_version we are sending changes since.
+ * @param {Array}      changes Array of change rows from crsql_changes().
+ *   Each row: [table, pk, cid, val, col_version, db_version, site_id, cl, seq]
+ * @returns {Uint8Array} Binary-encoded message.
+ */
+function encodeChangesMsg(siteId, since, changes) {
+  const enc = createEncoder();
+  writeUint8(enc, Tag.Changes);
+  // sender
+  writeUint8Array(enc, siteId);
+  // since: [version, seq] pair — matches vlcn.io wire format
+  writeBigInt64(enc, since);
+  writeVarInt(enc, 0); // seq component of since (0 = send all from this version)
+  // number of changes
+  writeVarUint(enc, changes.length);
+  for (const row of changes) {
+    // [table, pk, cid, val, col_version, db_version, site_id, cl, seq]
+    const [table, pk, cid, val, colVersion, dbVersion, changeSiteId, cl, seq] = row;
+    writeVarString(enc, table);
+    // pk is a packed blob from crsqlite
+    writeVarUint8Array(enc, pk instanceof Uint8Array ? pk : _textEncoder.encode(String(pk)));
+    writeVarString(enc, cid);
+    writeTypedValue(enc, val);
+    writeBigInt64(enc, BigInt(colVersion));
+    writeBigInt64(enc, BigInt(dbVersion));
+    // site_id: NULL tag (0) for null, BLOB tag (5) + raw 16 bytes otherwise
+    if (changeSiteId != null && changeSiteId.length > 0) {
+      writeUint8(enc, 5); // BLOB
+      const sid = changeSiteId instanceof Uint8Array ? changeSiteId : new Uint8Array(changeSiteId);
+      if (sid.length !== 16) throw new Error(`[Sync] change site_id has wrong length: ${sid.length}`);
+      writeUint8Array(enc, sid); // raw 16 bytes, no length prefix
+    } else {
+      writeUint8(enc, 0); // NULL
+    }
+    writeBigInt64(enc, BigInt(cl));
+    writeVarInt(enc, Number(seq));
+  }
+  return toUint8Array(enc);
+}
+
+/**
+ * Decode an incoming binary message from the server.
+ *
+ * @param {ArrayBuffer} data  Raw binary message.
+ * @returns {{ tag: number, changes?: Array, sender?: Uint8Array }}
+ */
+function decodeMessage(data) {
+  const dec = createDecoder(data);
+  const tag = readUint8(dec);
+
+  switch (tag) {
+    case Tag.Changes: {
+      const sender = readUint8ArrayFixed(dec, 16);
+      const sinceVersion = readBigInt64(dec);
+      const sinceSeq = readVarInt(dec);
+      const count = readVarUint(dec);
+      const changes = [];
+      for (let i = 0; i < count; i++) {
+        const table = readVarString(dec);
+        const pk = readVarUint8Array(dec);
+        const cid = readVarString(dec);
+        const val = readTypedValue(dec);
+        const colVersion = readBigInt64(dec);
+        const dbVersion = readBigInt64(dec);
+        // site_id: NULL tag (0) means null, BLOB tag (5) means 16 raw bytes
+        const siteIdTag = readUint8(dec);
+        const siteId = siteIdTag === 0 ? null : readUint8ArrayFixed(dec, 16);
+        const cl = readBigInt64(dec);
+        const seq = readVarInt(dec);
+        changes.push([table, pk, cid, val, colVersion, dbVersion, siteId, cl, seq]);
+      }
+      return { tag, sender, since: [sinceVersion, sinceSeq], changes };
+    }
+
+    case Tag.StartStreaming:
+      return { tag };
+
+    case Tag.RejectChanges:
+      return { tag };
+
+    case Tag.Pong:
+      return { tag };
+
+    case Tag.Ping:
+      return { tag };
+
+    default:
+      console.warn(`[Sync] Unknown message tag: ${tag}`);
+      return { tag };
+  }
+}
+
+// ── Database handle ───────────────────────────────────────────────────────────
 
 // Lazily-resolved reference to the live crsqlite DB handle.
 // The db-module.js initDatabase() stores the open handle on this module-level
@@ -31,7 +391,6 @@ function getDb() {
 
 /**
  * Get the current db_version (site's latest change version).
- * Used to determine which changes to send.
  *
  * @returns {Promise<bigint>} The current db_version.
  */
@@ -45,17 +404,31 @@ async function getDbVersion() {
 }
 
 /**
- * Get the site_id for this database instance (a unique 16-byte identifier).
+ * Get the 16-byte site identifier for this client.
+ * Required for the AnnouncePresence message.
  *
- * @returns {Promise<Uint8Array>} The site_id bytes.
+ * @returns {Promise<Uint8Array>} The 16-byte site_id.
  */
 async function getSiteId() {
   const db = getDb();
   const rows = await db.execA("SELECT crsql_site_id()");
   if (rows && rows.length > 0) {
-    return rows[0][0];
+    const raw = rows[0][0];
+    if (raw instanceof Uint8Array) return raw;
+    // If returned as hex string, convert
+    if (typeof raw === "string") {
+      const hex = raw.replace(/-/g, "");
+      if (hex.length !== 32) {
+        throw new Error(`[Sync] site_id hex has wrong length: ${hex.length} (expected 32)`);
+      }
+      const bytes = new Uint8Array(16);
+      for (let i = 0; i < 16; i++) {
+        bytes[i] = parseInt(hex.substring(i * 2, i * 2 + 2), 16);
+      }
+      return bytes;
+    }
   }
-  throw new Error("[Sync] Could not read crsql_site_id()");
+  throw new Error("[Sync] Could not determine site_id — database may not be initialized");
 }
 
 /**
@@ -69,11 +442,27 @@ async function getSiteId() {
  */
 async function getChangesSince(sinceVersion) {
   const db = getDb();
+  // Force crsqlite to flush internal state before querying changes.
+  // The crsql_changes virtual table reads from crsqlite's internal tracking
+  // tables, which may not reflect recent writes until the current auto-commit
+  // transaction completes. Calling crsql_db_version() in a fresh statement
+  // ensures any pending writes are visible.
+  const dbVer = await db.execA("SELECT crsql_db_version()");
+  console.log(`[Sync] Current db_version: ${dbVer?.[0]?.[0]}`);
+
   const rows = await db.execA(
     "SELECT [table], [pk], [cid], [val], [col_version], [db_version], [site_id], [cl], [seq] " +
     "FROM crsql_changes WHERE db_version > ?",
-    [sinceVersion]
+    [Number(sinceVersion)]
   );
+  // Log changeset table breakdown for debugging
+  if (rows && rows.length > 0) {
+    const tables = {};
+    for (const r of rows) { tables[r[0]] = (tables[r[0]] || 0) + 1; }
+    console.log(`[Sync] getChangesSince(${sinceVersion}): ${rows.length} changes — ${JSON.stringify(tables)}`);
+  } else {
+    console.log(`[Sync] getChangesSince(${sinceVersion}): 0 changes`);
+  }
   return rows || [];
 }
 
@@ -84,37 +473,45 @@ async function getChangesSince(sinceVersion) {
  *
  * @param {Array<Array>} changes  Array of change rows (same column order as getChangesSince).
  */
-async function applyChanges(changes) {
+async function applyChanges(changes, sender) {
   if (!changes || changes.length === 0) return;
 
   const db = getDb();
-  await db.exec("BEGIN");
+  // NOTE: crsqlite requires INSERT INTO crsql_changes to run outside an
+  // explicit transaction (auto-commit mode). Wrapping in BEGIN/COMMIT
+  // causes the virtual table to silently discard changes.
   try {
     for (const change of changes) {
+      // [table, pk, cid, val, col_version, db_version, site_id, cl, seq]
+      // col_version(4), db_version(5), cl(7) are BigInt from the decoder.
+      // crsqlite-wasm's exec may not handle BigInt parameters — coerce to
+      // Number (safe for realistic version values well within Number.MAX_SAFE_INTEGER).
+      //
+      // site_id: the server sends NULL as a bandwidth optimization (hub-and-spoke).
+      // crsqlite needs a non-NULL site_id to distinguish remote from local
+      // changes. Use the message sender's site_id when the per-row value is NULL.
+      const siteId = change[6] != null ? change[6] : sender;
+      const coerced = [
+        change[0],                                       // table (string)
+        change[1],                                       // pk (Uint8Array)
+        change[2],                                       // cid (string)
+        typeof change[3] === "bigint" ? Number(change[3]) : change[3], // val (mixed — coerce BigInt)
+        Number(change[4]),                               // col_version
+        Number(change[5]),                               // db_version
+        siteId,                                          // site_id (Uint8Array)
+        Number(change[7]),                               // cl
+        change[8],                                       // seq (already Number)
+      ];
       await db.exec(
         "INSERT INTO crsql_changes ([table], [pk], [cid], [val], [col_version], [db_version], [site_id], [cl], [seq]) " +
         "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-        change
+        coerced
       );
     }
-    await db.exec("COMMIT");
   } catch (e) {
-    await db.exec("ROLLBACK");
+    console.error("[Sync] applyChanges INSERT error:", e);
     throw e;
   }
-}
-
-/**
- * Encode changesets as JSON for WebSocket transmission.
- * BigInt values are converted to strings for JSON compatibility.
- *
- * @param {Array<Array>} changes  Change rows from getChangesSince.
- * @returns {string} JSON-encoded changes.
- */
-function encodeChanges(changes) {
-  return JSON.stringify(changes, (_key, value) =>
-    typeof value === "bigint" ? value.toString() : value
-  );
 }
 
 /**
@@ -133,7 +530,7 @@ function buildWsUrl(syncId) {
 
   // Convert http(s) to ws(s).
   const wsBase = base.replace(/^http/, "ws");
-  return `${wsBase.replace(/\/$/, "")}/sync/${syncId}/ws`;
+  return `${wsBase.replace(/\/$/, "")}/sync/${syncId}`;
 }
 
 // ── Sync-state tracking ───────────────────────────────────────────────────────
@@ -160,60 +557,70 @@ function setLastSentVersion(version) {
   }
 }
 
-// Track the last version we received from the server so we can tell the
-// server which changes to send us.
-const LAST_RECEIVED_KEY = "sync_last_received_version";
-
-function getLastReceivedVersion() {
-  try {
-    const raw = localStorage.getItem(LAST_RECEIVED_KEY);
-    return raw ? BigInt(raw) : 0n;
-  } catch {
-    return 0n;
-  }
-}
-
-function setLastReceivedVersion(version) {
-  try {
-    localStorage.setItem(LAST_RECEIVED_KEY, version.toString());
-  } catch {
-    // Ignore.
-  }
-}
-
 /**
- * Run one sync cycle over WebSocket.
+ * Run one sync cycle over WebSocket using the vlcn.io binary wire protocol.
  *
- * Protocol:
- *   1. Client opens a WebSocket to /sync/:sync_id/ws
- *   2. Client sends: { type: "push", site_id, changes, last_received_version }
- *   3. Server responds: { type: "pull", changes }
- *   4. Client applies received changes, sends: { type: "ack" }
- *   5. Server sends: { type: "done" } — connection closes.
+ * Protocol flow:
+ *   1. On open: send AnnouncePresence (tag=1) with our site_id and empty lastSeens
+ *   2. Receive: server sends Changes (tag=2) with remote changesets, or
+ *      StartStreaming (tag=4) indicating it has no changes
+ *   3. Send: Changes (tag=2) with our local changesets since lastSent
+ *   4. Close: update lastSentVersion only on successful close (code 1000)
  *
  * @param {string} syncId       The sync slot identifier.
- * @param {string} syncSecret   Auth secret (sent as first message for auth).
+ * @param {string} _syncSecret  Auth secret (currently unused by server).
  * @param {number} timeoutMs    Max time to wait for the sync cycle (default 15s).
  * @returns {Promise<string>}   Outcome: "synced" | "no_changes" | "offline" | "error:<msg>"
  */
-export async function runSyncCycle(syncId, syncSecret, timeoutMs = 15000) {
+export async function runSyncCycle(syncId, _syncSecret, timeoutMs = 15000) {
   try {
     getDb(); // Validate DB is registered before proceeding.
-    const siteId = await getSiteId();
 
-    // Determine what to send.
+    // Gather prerequisites before opening the WebSocket.
+    const siteId = await getSiteId();
     const lastSent = getLastSentVersion();
     const localChanges = await getChangesSince(lastSent);
-    const lastReceived = getLastReceivedVersion();
 
     const wsUrl = buildWsUrl(syncId);
     console.log(`[Sync] Opening WebSocket to ${wsUrl}`);
 
+    // Encode room info in sec-websocket-protocol as vlcn.io expects.
+    // Strip base64 padding (`=`) — it is not allowed in WebSocket subprotocol
+    // values per RFC 6455 §4.1.  The vlcn.io server decodes unpadded base64.
+    const roomMeta = btoa(`room=${syncId},schemaName=${SCHEMA_NAME},schemaVersion=${SCHEMA_VERSION}`).replace(/=+$/, "");
+
     return await new Promise((resolve) => {
       let settled = false;
+      let receivedRemoteChanges = false;
+      let sentLocalChanges = false;
+      let versionAtSend = 0n;
+
+      // Deferred close timer — gives in-flight server messages time to arrive
+      // and be fully processed before we close the WebSocket.
+      let closeTimer = null;
+
+      /**
+       * Schedule a graceful close after a short delay.  Any new message
+       * arrival resets the timer so that in-progress applyChanges() calls
+       * finish before the connection is torn down.
+       */
+      const scheduleClose = () => {
+        if (closeTimer) clearTimeout(closeTimer);
+        closeTimer = setTimeout(async () => {
+          closeTimer = null;
+          // versionAtSend is captured in sendLocalChanges() BEFORE remote
+          // changes are applied — don't re-read getDbVersion() here, as it
+          // would include the higher version from applied remote changes.
+          if (ws.readyState === WebSocket.OPEN) {
+            ws.close(1000, "sync complete");
+          }
+        }, 300);
+      };
+
       const timer = setTimeout(() => {
         if (!settled) {
           settled = true;
+          if (closeTimer) clearTimeout(closeTimer);
           try { ws.close(); } catch { /* ignore */ }
           resolve("offline");
         }
@@ -221,7 +628,7 @@ export async function runSyncCycle(syncId, syncSecret, timeoutMs = 15000) {
 
       let ws;
       try {
-        ws = new WebSocket(wsUrl);
+        ws = new WebSocket(wsUrl, [roomMeta]);
       } catch (e) {
         clearTimeout(timer);
         console.warn("[Sync] WebSocket constructor failed:", e);
@@ -229,67 +636,134 @@ export async function runSyncCycle(syncId, syncSecret, timeoutMs = 15000) {
         return;
       }
 
+      // vlcn.io uses binary frames
+      ws.binaryType = "arraybuffer";
+
       ws.onopen = () => {
-        console.log("[Sync] WebSocket connected");
-        // Send auth + changes in one message.
-        const payload = {
-          type: "push",
-          sync_secret: syncSecret,
-          site_id: Array.from(siteId instanceof Uint8Array ? siteId : []),
-          changes: JSON.parse(encodeChanges(localChanges)),
-          last_received_version: lastReceived.toString(),
-        };
-        ws.send(JSON.stringify(payload));
+        console.log("[Sync] WebSocket connected, sending AnnouncePresence");
+        try {
+          // Send AnnouncePresence with empty lastSeens.
+          // TODO(perf): persist lastSeens to localStorage to enable incremental sync.
+          const msg = encodeAnnouncePresence(siteId, []);
+          ws.send(msg);
+        } catch (e) {
+          console.error("[Sync] Error sending AnnouncePresence:", e);
+          clearTimeout(timer);
+          if (closeTimer) clearTimeout(closeTimer);
+          if (!settled) {
+            settled = true;
+            try { ws.close(4000, "announce error"); } catch { /* ignore */ }
+            resolve("error:announce failed");
+          }
+        }
+      };
+
+      /**
+       * Send our local changes after receiving the server's changes or StartStreaming.
+       * Does NOT close the WebSocket — scheduleClose() handles that after a
+       * grace period so any remaining server Changes can arrive and be applied.
+       */
+      const sendLocalChanges = async () => {
+        if (sentLocalChanges) return;
+        sentLocalChanges = true;
+        try {
+          if (localChanges.length > 0) {
+            console.log(`[Sync] Sending ${localChanges.length} changes with since=${lastSent}`);
+            const msg = encodeChangesMsg(siteId, lastSent, localChanges);
+            ws.send(msg);
+            console.log(`[Sync] Sent ${localChanges.length} local changes (${msg.byteLength} bytes)`);
+          }
+          // Capture the db_version at send time. When triggered by StartStreaming
+          // this is before remote changes; when triggered by the Changes handler,
+          // remote changes have already been applied. Either way, this version
+          // represents the state the server should track for our next sync.
+          try {
+            versionAtSend = await getDbVersion();
+          } catch { /* ignore */ }
+          // Don't close immediately — the server may still be sending Changes
+          // from its OutboundStream.  scheduleClose() waits 300ms for any
+          // remaining messages before closing.
+          scheduleClose();
+        } catch (e) {
+          console.error("[Sync] Error sending changes:", e);
+          if (closeTimer) clearTimeout(closeTimer);
+          ws.close(4000, "send error"); // Non-1000 so onclose treats as failure
+        }
       };
 
       ws.onmessage = async (event) => {
         try {
-          const msg = JSON.parse(event.data);
+          if (!(event.data instanceof ArrayBuffer)) {
+            console.warn("[Sync] Unexpected non-binary message, ignoring");
+            return;
+          }
 
-          if (msg.type === "pull") {
-            // Apply remote changes.
-            const remoteChanges = msg.changes || [];
-            if (remoteChanges.length > 0) {
-              console.log(`[Sync] Applying ${remoteChanges.length} remote changes`);
-              await applyChanges(remoteChanges);
+          const decoded = decodeMessage(event.data);
 
-              // Update last-received version from the server's report.
-              if (msg.server_db_version) {
-                setLastReceivedVersion(BigInt(msg.server_db_version));
+          switch (decoded.tag) {
+            case Tag.Changes: {
+              // Pause the close timer while we apply changes — prevents
+              // onclose from firing mid-applyChanges and settling the
+              // promise before receivedRemoteChanges is set.
+              if (closeTimer) { clearTimeout(closeTimer); closeTimer = null; }
+              if (decoded.changes && decoded.changes.length > 0) {
+                const remoteTables = {};
+                for (const r of decoded.changes) { remoteTables[r[0]] = (remoteTables[r[0]] || 0) + 1; }
+                console.log(`[Sync] Received ${decoded.changes.length} remote changes — ${JSON.stringify(remoteTables)}`);
+                await applyChanges(decoded.changes, decoded.sender);
+                receivedRemoteChanges = true;
+              } else {
+                console.log("[Sync] Received empty Changes message");
               }
+              // After receiving changes, send ours (or reschedule close)
+              if (!sentLocalChanges) {
+                await sendLocalChanges();
+              } else {
+                scheduleClose();
+              }
+              break;
             }
 
-            // Update last-sent version now that the server has our changes.
-            const currentVersion = await getDbVersion();
-            setLastSentVersion(currentVersion);
+            case Tag.StartStreaming: {
+              console.log("[Sync] Server ready for streaming, sending local changes");
+              await sendLocalChanges();
+              break;
+            }
 
-            // Acknowledge.
-            ws.send(JSON.stringify({ type: "ack" }));
-          } else if (msg.type === "done") {
-            clearTimeout(timer);
-            if (!settled) {
-              settled = true;
-              ws.close();
-              const hadChanges =
-                localChanges.length > 0 ||
-                (msg.applied_count && msg.applied_count > 0);
-              resolve(hadChanges ? "synced" : "no_changes");
+            case Tag.RejectChanges: {
+              console.warn("[Sync] Server rejected our changes");
+              clearTimeout(timer);
+              if (closeTimer) clearTimeout(closeTimer);
+              if (!settled) {
+                settled = true;
+                ws.close(4001, "changes rejected");
+                resolve("error:changes rejected");
+              }
+              break;
             }
-          } else if (msg.type === "error") {
-            clearTimeout(timer);
-            if (!settled) {
-              settled = true;
-              ws.close();
-              resolve(`error:${msg.message || "unknown"}`);
+
+            case Tag.Pong:
+            case Tag.Ping: {
+              // Respond to ping with pong
+              if (decoded.tag === Tag.Ping) {
+                const pong = createEncoder();
+                writeUint8(pong, Tag.Pong);
+                ws.send(toUint8Array(pong));
+              }
+              break;
             }
+
+            default:
+              console.warn(`[Sync] Unhandled message tag: ${decoded.tag}`);
           }
         } catch (e) {
           console.error("[Sync] Error processing message:", e);
           clearTimeout(timer);
+          if (closeTimer) clearTimeout(closeTimer);
           if (!settled) {
             settled = true;
             try { ws.close(); } catch { /* ignore */ }
-            resolve(`error:${e.message || "parse error"}`);
+            resolve(`error:${e.message || "decode error"}`);
           }
         }
       };
@@ -297,6 +771,7 @@ export async function runSyncCycle(syncId, syncSecret, timeoutMs = 15000) {
       ws.onerror = (event) => {
         console.warn("[Sync] WebSocket error:", event);
         clearTimeout(timer);
+        if (closeTimer) clearTimeout(closeTimer);
         if (!settled) {
           settled = true;
           resolve("offline");
@@ -305,10 +780,19 @@ export async function runSyncCycle(syncId, syncSecret, timeoutMs = 15000) {
 
       ws.onclose = (event) => {
         clearTimeout(timer);
+        if (closeTimer) clearTimeout(closeTimer);
         if (!settled) {
           settled = true;
-          if (event.code === 1000 || event.code === 1005) {
-            resolve("no_changes");
+          if (event.code === 1000) {
+            // Only update lastSentVersion on successful close.
+            // versionAtSend was captured in sendLocalChanges() BEFORE remote
+            // changes were applied, so it reflects only our local state.
+            if (sentLocalChanges && versionAtSend > 0n) {
+              console.log(`[Sync] Setting lastSentVersion to ${versionAtSend}`);
+              setLastSentVersion(versionAtSend);
+            }
+            const hadChanges = localChanges.length > 0 || receivedRemoteChanges;
+            resolve(hadChanges ? "synced" : "no_changes");
           } else {
             resolve("offline");
           }
@@ -325,23 +809,22 @@ export async function runSyncCycle(syncId, syncSecret, timeoutMs = 15000) {
  * Check whether the sync server is reachable (lightweight HTTP health check).
  * Falls back to "offline" on any error.
  *
- * @param {string} syncId  The sync slot identifier.
+ * @param {string} syncId  The sync slot identifier (unused — health is global).
  * @returns {Promise<boolean>} true if the server responded.
  */
-export async function checkSyncServerHealth(syncId) {
+export async function checkSyncServerHealth(_syncId) {
   try {
     let base = window.SYNC_BASE_URL || "";
     if (!base || base.includes("%%")) {
       base = window.location.origin + "/api";
     }
-    const url = `${base.replace(/\/$/, "")}/sync/${syncId}/metadata`;
+    const url = `${base.replace(/\/$/, "")}/health`;
     const resp = await fetch(url, {
       method: "GET",
       mode: "cors",
       signal: AbortSignal.timeout(5000),
     });
-    // 404 is fine — means the slot doesn't exist yet but the server is up.
-    return resp.ok || resp.status === 404;
+    return resp.ok;
   } catch {
     return false;
   }

--- a/src/app.rs
+++ b/src/app.rs
@@ -89,11 +89,11 @@ pub enum Route {
     #[route("/workout/history")]
     WorkoutHistory,
     #[route("/workout/history/:exercise_id")]
-    WorkoutHistoryExercise { exercise_id: i64 },
+    WorkoutHistoryExercise { exercise_id: String },
     #[route("/library")]
     LibraryTab,
     #[route("/library/:exercise_id")]
-    LibraryExercise { exercise_id: i64 },
+    LibraryExercise { exercise_id: String },
     #[route("/settings")]
     SettingsTab,
     #[end_layout]
@@ -251,7 +251,7 @@ fn WorkoutHistory() -> Element {
 }
 
 #[component]
-fn WorkoutHistoryExercise(exercise_id: i64) -> Element {
+fn WorkoutHistoryExercise(exercise_id: String) -> Element {
     let state = consume_context::<WorkoutState>();
     let navigator = use_navigator();
     rsx! { HistoryView { state, exercise_id: Some(exercise_id), on_back: move |_| { navigator.push(Route::WorkoutHistory); } } }
@@ -269,7 +269,7 @@ fn SettingsTab() -> Element {
 }
 
 #[component]
-fn LibraryExercise(exercise_id: i64) -> Element {
+fn LibraryExercise(exercise_id: String) -> Element {
     let workout_state = consume_context::<WorkoutState>();
     let navigator = use_navigator();
     let mut show_edit_form = use_signal(|| false);
@@ -277,7 +277,7 @@ fn LibraryExercise(exercise_id: i64) -> Element {
     let exercises = workout_state.exercises();
     let exercise = exercises
         .iter()
-        .find(|e| e.id == Some(exercise_id))
+        .find(|e| e.id.as_deref() == Some(exercise_id.as_str()))
         .cloned();
 
     let Some(exercise) = exercise else {
@@ -479,16 +479,16 @@ pub fn App() -> Element {
                 }
                 sync_attempted.set(true);
                 spawn(async move {
-                    log::debug!("[Sync] App ready — starting background sync");
+                    js_log("[Sync] App ready — starting background sync");
                     WorkoutStateManager::trigger_background_sync(&workout_state).await;
-                    log::debug!("[Sync] Background sync complete");
+                    js_log("[Sync] Background sync complete");
 
                     // Periodic sync every 30 seconds while the app is open.
                     loop {
                         gloo_timers::future::sleep(std::time::Duration::from_secs(30)).await;
-                        log::debug!("[Sync] Periodic sync tick");
+                        js_log("[Sync] Periodic sync tick");
                         WorkoutStateManager::trigger_background_sync(&workout_state).await;
-                        log::debug!("[Sync] Periodic sync complete");
+                        js_log("[Sync] Periodic sync complete");
                     }
                 });
             }
@@ -910,12 +910,12 @@ pub fn ActiveSession(state: WorkoutState, session: crate::state::WorkoutSession)
     let mut weight_input = use_signal(|| session.predicted.weight.map(|w| w as f64).unwrap_or(0.0));
 
     // Sync inputs when session or predicted changes (e.g., after logging a set or starting a new session)
-    let mut last_session_id = use_signal(|| session.session_id);
+    let mut last_session_id = use_signal(|| session.session_id.clone());
     let mut last_predicted = use_signal(|| session.predicted);
 
     if *last_session_id.peek() != session.session_id || *last_predicted.peek() != session.predicted
     {
-        last_session_id.set(session.session_id);
+        last_session_id.set(session.session_id.clone());
         last_predicted.set(session.predicted);
         reps_input.set(session.predicted.reps as f64);
         rpe_input.set(session.predicted.rpe as f64);
@@ -954,7 +954,7 @@ pub fn ActiveSession(state: WorkoutState, session: crate::state::WorkoutSession)
     };
 
     let navigator = use_navigator();
-    let history_exercise_id = session_for_display.exercise.id.unwrap_or(0);
+    let history_exercise_id = session_for_display.exercise.id.clone().unwrap_or_default();
 
     rsx! {
         div {
@@ -982,7 +982,7 @@ pub fn ActiveSession(state: WorkoutState, session: crate::state::WorkoutSession)
                                 "aria-label": "View exercise history",
                                 "data-testid": "history-icon-btn",
                                 onclick: move |_| {
-                                    navigator.push(Route::WorkoutHistoryExercise { exercise_id: history_exercise_id });
+                                    navigator.push(Route::WorkoutHistoryExercise { exercise_id: history_exercise_id.clone() });
                                 },
                                 svg {
                                     xmlns: "http://www.w3.org/2000/svg",
@@ -1151,11 +1151,11 @@ pub fn ActiveSession(state: WorkoutState, session: crate::state::WorkoutSession)
             }
 
             // Previous Sessions — collapsible history for this exercise (AC #1–#6)
-            if let Some(eid) = session_for_display.exercise.id {
+            if let Some(ref eid) = session_for_display.exercise.id {
                 PreviousSessions {
                     key: "{eid}",
                     state: state,
-                    exercise_id: eid,
+                    exercise_id: eid.clone(),
                     completed_sets_count: session_for_display.completed_sets.len(),
                 }
             }

--- a/src/components/exercise_form.rs
+++ b/src/components/exercise_form.rs
@@ -68,7 +68,7 @@ pub fn ExerciseForm(
     });
     let mut validation_error = use_signal(|| None::<String>);
 
-    let initial_id = initial_exercise.as_ref().and_then(|e| e.id);
+    let initial_id = initial_exercise.as_ref().and_then(|e| e.id.clone());
     let is_edit = initial_exercise.is_some();
 
     let handle_save = move |_| {
@@ -82,7 +82,7 @@ pub fn ExerciseForm(
         validation_error.set(None);
 
         let exercise = ExerciseMetadata {
-            id: initial_id,
+            id: initial_id.clone(),
             name,
             set_type_config: if is_weighted() {
                 SetTypeConfig::Weighted {

--- a/src/components/history_view.rs
+++ b/src/components/history_view.rs
@@ -9,7 +9,7 @@ use web_sys::{IntersectionObserver, IntersectionObserverEntry, IntersectionObser
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct ExerciseGroup {
-    pub exercise_id: i64,
+    pub exercise_id: String,
     pub exercise_name: String,
     pub sets: Vec<HistorySet>,
 }
@@ -56,7 +56,7 @@ pub fn group_sets_by_day(sets: &[HistorySet], utc_offset_minutes: i32) -> Vec<Da
         {
             Some(eg) => eg.sets.push(set.clone()),
             None => day.exercises.push(ExerciseGroup {
-                exercise_id: set.exercise_id,
+                exercise_id: set.exercise_id.clone(),
                 exercise_name: set.exercise_name.clone(),
                 sets: vec![set.clone()],
             }),
@@ -118,18 +118,21 @@ const PAGE_SIZE: i64 = 20;
 pub fn HistoryView(
     state: WorkoutState,
     /// When `Some`, the view defaults to the per-exercise scope for this exercise.
-    exercise_id: Option<i64>,
+    exercise_id: Option<String>,
     /// When `Some`, a back button is rendered and this handler is called on click.
     /// Omit to suppress the back button (e.g. when the parent already provides one).
     on_back: Option<EventHandler<()>>,
 ) -> Element {
     // Track exercise_id prop in a signal for reactivity in effects
-    let mut eid_signal = use_signal(|| exercise_id);
+    let mut eid_signal = use_signal(|| exercise_id.clone());
     if *eid_signal.peek() != exercise_id {
-        eid_signal.set(exercise_id);
+        eid_signal.set(exercise_id.clone());
     }
 
-    let initial_scope = if exercise_id.is_some() {
+    let exercise_id_is_some = exercise_id.is_some();
+    let exercise_id_is_none = exercise_id.is_none();
+
+    let initial_scope = if exercise_id_is_some {
         HistoryScope::Exercise
     } else {
         HistoryScope::All
@@ -137,7 +140,7 @@ pub fn HistoryView(
 
     let mut scope = use_signal(|| initial_scope);
     // User-selected exercise filter (only used when exercise_id prop is None)
-    let mut user_filter_eid = use_signal(|| None::<i64>);
+    let mut user_filter_eid = use_signal(|| None::<String>);
     // Available exercises for the filter dropdown
     let mut available_exercises = use_signal(Vec::<crate::models::ExerciseMetadata>::new);
 
@@ -173,12 +176,15 @@ pub fn HistoryView(
             let eid = eid_signal();
             let user_eid = user_filter_eid();
             let effective_eid = eid.or(user_eid);
-            if let Some(id) = effective_eid {
+            if let Some(ref id) = effective_eid {
                 let state_ref = state_ref;
+                let id = id.clone();
                 spawn(async move {
                     if let Some(db) = state_ref.database()
                         && let Ok(exercises) = db.get_exercises().await
-                        && let Some(ex) = exercises.iter().find(|e| e.id == Some(id))
+                        && let Some(ex) = exercises
+                            .iter()
+                            .find(|e| e.id.as_deref() == Some(id.as_str()))
                     {
                         exercise_name.set(ex.name.clone());
                     }
@@ -192,7 +198,7 @@ pub fn HistoryView(
         let state_ref = state;
         use_effect(move || {
             let _ = eid_signal(); // track changes
-            if exercise_id.is_none() {
+            if exercise_id_is_none {
                 spawn(async move {
                     if let Some(db) = state_ref.database()
                         && let Ok(exercises) = db.get_exercises().await
@@ -246,7 +252,7 @@ pub fn HistoryView(
                 return;
             }
             let current_scope = scope();
-            let eid = eid_signal.peek().or(*user_filter_eid.peek());
+            let eid = eid_signal.peek().clone().or(user_filter_eid.peek().clone());
             let offset = sets.read().len() as i64;
             spawn(async move {
                 loading.set(true);
@@ -307,7 +313,7 @@ pub fn HistoryView(
                 class: "flex rounded-lg overflow-hidden border border-base-300 mb-6 sticky top-0 bg-base-100 z-10",
                 "data-testid": "history-scope-toggle",
 
-                if exercise_id.is_some() {
+                if exercise_id_is_some {
                     button {
                         class: if scope() == HistoryScope::Exercise {
                             "flex-1 py-2 text-sm font-semibold bg-primary text-primary-content"
@@ -320,7 +326,7 @@ pub fn HistoryView(
                     }
                 }
 
-                if exercise_id.is_none() {
+                if exercise_id_is_none {
                     select {
                         class: "flex-1 py-2 text-sm font-semibold bg-base-100 border-0 outline-none cursor-pointer",
                         "data-testid": "exercise-filter-select",
@@ -329,17 +335,17 @@ pub fn HistoryView(
                             if val.is_empty() {
                                 user_filter_eid.set(None);
                                 scope.set(HistoryScope::All);
-                            } else if let Ok(id) = val.parse::<i64>() {
-                                user_filter_eid.set(Some(id));
+                            } else {
+                                user_filter_eid.set(Some(val));
                                 scope.set(HistoryScope::Exercise);
                             }
                         },
                         option { value: "", "All exercises" }
                         for ex in available_exercises.read().iter() {
-                            if let Some(id) = ex.id {
+                            if let Some(ref id) = ex.id {
                                 option {
                                     value: "{id}",
-                                    selected: user_filter_eid() == Some(id),
+                                    selected: user_filter_eid().as_deref() == Some(id.as_str()),
                                     "{ex.name}"
                                 }
                             }
@@ -347,7 +353,7 @@ pub fn HistoryView(
                     }
                 }
 
-                if exercise_id.is_some() {
+                if exercise_id_is_some {
                     button {
                         class: if scope() == HistoryScope::All {
                             "flex-1 py-2 text-sm font-semibold bg-primary text-primary-content"
@@ -426,7 +432,7 @@ pub fn HistoryView(
                                                                         spawn(async move {
                                                                             if let Some(db) = state_ref.database()
                                                                                 && let Ok(exercises) = db.get_exercises().await
-                                                                                && let Some(ex) = exercises.iter().find(|e| e.id == Some(set.exercise_id))
+                                                                                && let Some(ex) = exercises.iter().find(|e| e.id.as_deref() == Some(set.exercise_id.as_str()))
                                                                             {
                                                                                 editing_exercise.set(Some(ex.clone()));
                                                                                 editing_set.set(Some(set));
@@ -587,13 +593,13 @@ pub fn HistoryView(
 async fn fetch_page(
     db: &Database,
     scope: HistoryScope,
-    exercise_id: Option<i64>,
+    exercise_id: Option<String>,
     limit: i64,
     offset: i64,
 ) -> Result<Vec<HistorySet>, crate::state::DatabaseError> {
     match scope {
         HistoryScope::Exercise => {
-            if let Some(id) = exercise_id {
+            if let Some(ref id) = exercise_id {
                 db.get_sets_for_exercise(id, limit, offset).await
             } else {
                 db.get_all_sets_paginated(limit, offset).await
@@ -617,14 +623,14 @@ mod tests {
 
     fn make_set(
         id: i64,
-        exercise_id: i64,
+        exercise_id: &str,
         name: &str,
         set_number: u32,
         recorded_at: f64,
     ) -> HistorySet {
         HistorySet {
             id,
-            exercise_id,
+            exercise_id: exercise_id.to_string(),
             exercise_name: name.to_string(),
             set_number,
             reps: 8,
@@ -644,7 +650,13 @@ mod tests {
 
     #[test]
     fn test_single_set_single_day() {
-        let sets = vec![make_set(1, 1, "Bench Press", 1, DAY1_START + 3_600_000.0)];
+        let sets = vec![make_set(
+            1,
+            "ex-1",
+            "Bench Press",
+            1,
+            DAY1_START + 3_600_000.0,
+        )];
         let groups = group_sets_by_day(&sets, 0);
         assert_eq!(groups.len(), 1);
         assert_eq!(groups[0].date_label, "2025-01-01");
@@ -655,8 +667,8 @@ mod tests {
     #[test]
     fn test_two_sets_same_day_same_exercise() {
         let sets = vec![
-            make_set(2, 1, "Squat", 2, DAY1_START + 7_200_000.0),
-            make_set(1, 1, "Squat", 1, DAY1_START + 3_600_000.0),
+            make_set(2, "ex-1", "Squat", 2, DAY1_START + 7_200_000.0),
+            make_set(1, "ex-1", "Squat", 1, DAY1_START + 3_600_000.0),
         ];
         let groups = group_sets_by_day(&sets, 0);
         assert_eq!(groups.len(), 1, "Should be one day group");
@@ -668,8 +680,8 @@ mod tests {
     fn test_two_exercises_same_day_share_one_date_header() {
         // AC #5: Multiple exercises on the same day appear under one date header
         let sets = vec![
-            make_set(2, 2, "Deadlift", 1, DAY1_START + 7_200_000.0),
-            make_set(1, 1, "Bench Press", 1, DAY1_START + 3_600_000.0),
+            make_set(2, "ex-2", "Deadlift", 1, DAY1_START + 7_200_000.0),
+            make_set(1, "ex-1", "Bench Press", 1, DAY1_START + 3_600_000.0),
         ];
         let groups = group_sets_by_day(&sets, 0);
         assert_eq!(groups.len(), 1, "One date header for same day");
@@ -684,8 +696,8 @@ mod tests {
     fn test_two_sets_different_days() {
         // AC #4: reverse-chronological, grouped by day
         let sets = vec![
-            make_set(2, 1, "Squat", 1, DAY2_START + 3_600_000.0),
-            make_set(1, 1, "Squat", 1, DAY1_START + 3_600_000.0),
+            make_set(2, "ex-1", "Squat", 1, DAY2_START + 3_600_000.0),
+            make_set(1, "ex-1", "Squat", 1, DAY1_START + 3_600_000.0),
         ];
         let groups = group_sets_by_day(&sets, 0);
         assert_eq!(groups.len(), 2);
@@ -697,7 +709,7 @@ mod tests {
     fn test_timezone_offset_shifts_day_boundary() {
         // A set at 2025-01-01 23:00 UTC is 2025-01-02 01:00 in UTC+2
         let set_ms = DAY1_START + 23.0 * 3_600_000.0;
-        let sets = vec![make_set(1, 1, "Press", 1, set_ms)];
+        let sets = vec![make_set(1, "ex-1", "Press", 1, set_ms)];
 
         let utc_groups = group_sets_by_day(&sets, 0);
         assert_eq!(utc_groups[0].date_label, "2025-01-01");
@@ -728,9 +740,9 @@ mod tests {
     fn test_sets_within_exercise_group_are_chronological() {
         // DB returns newest first: set 3, 2, 1
         let sets = vec![
-            make_set(3, 1, "Squat", 3, DAY1_START + 10_800_000.0), // 3 h
-            make_set(2, 1, "Squat", 2, DAY1_START + 7_200_000.0),  // 2 h
-            make_set(1, 1, "Squat", 1, DAY1_START + 3_600_000.0),  // 1 h
+            make_set(3, "ex-1", "Squat", 3, DAY1_START + 10_800_000.0), // 3 h
+            make_set(2, "ex-1", "Squat", 2, DAY1_START + 7_200_000.0),  // 2 h
+            make_set(1, "ex-1", "Squat", 1, DAY1_START + 3_600_000.0),  // 1 h
         ];
         let groups = group_sets_by_day(&sets, 0);
         assert_eq!(groups.len(), 1);
@@ -754,10 +766,10 @@ mod tests {
     fn test_day_groups_reverse_chrono_sets_within_group_chrono() {
         // Two days; within each day two sets arrive newest-first from DB
         let sets = vec![
-            make_set(4, 1, "Squat", 2, DAY2_START + 7_200_000.0), // day2 set2 (newer)
-            make_set(3, 1, "Squat", 1, DAY2_START + 3_600_000.0), // day2 set1 (older)
-            make_set(2, 1, "Squat", 2, DAY1_START + 7_200_000.0), // day1 set2 (newer)
-            make_set(1, 1, "Squat", 1, DAY1_START + 3_600_000.0), // day1 set1 (older)
+            make_set(4, "ex-1", "Squat", 2, DAY2_START + 7_200_000.0), // day2 set2 (newer)
+            make_set(3, "ex-1", "Squat", 1, DAY2_START + 3_600_000.0), // day2 set1 (older)
+            make_set(2, "ex-1", "Squat", 2, DAY1_START + 7_200_000.0), // day1 set2 (newer)
+            make_set(1, "ex-1", "Squat", 1, DAY1_START + 3_600_000.0), // day1 set1 (older)
         ];
         let groups = group_sets_by_day(&sets, 0);
         assert_eq!(groups.len(), 2);

--- a/src/components/library_view.rs
+++ b/src/components/library_view.rs
@@ -164,11 +164,11 @@ pub fn LibraryView() -> Element {
                     class: "grid gap-4",
                     for exercise in filtered_exercises() {
                         div {
-                            key: "{exercise.id.unwrap_or(0)}",
+                            key: "{exercise.id.clone().unwrap_or_default()}",
                             class: "card bg-base-100 shadow-md hover:shadow-lg transition-all border border-base-200 cursor-pointer",
                             onclick: {
-                                let id = exercise.id.unwrap_or(0);
-                                move |_| { navigator.push(Route::LibraryExercise { exercise_id: id }); }
+                                let id = exercise.id.clone().unwrap_or_default();
+                                move |_| { navigator.push(Route::LibraryExercise { exercise_id: id.clone() }); }
                             },
                             div {
                                 class: "card-body p-4",

--- a/src/components/previous_sessions.rs
+++ b/src/components/previous_sessions.rs
@@ -32,7 +32,7 @@ fn start_of_today_utc_ms() -> f64 {
 #[component]
 pub fn PreviousSessions(
     state: WorkoutState,
-    exercise_id: i64,
+    exercise_id: String,
     /// Pass `session.completed_sets.len()` so the panel refreshes on each new set.
     completed_sets_count: usize,
 ) -> Element {
@@ -42,7 +42,7 @@ pub fn PreviousSessions(
     let mut loading = use_signal(|| false);
 
     // Track props in signals so use_effect can subscribe to them
-    let mut eid_signal = use_signal(|| exercise_id);
+    let mut eid_signal = use_signal(|| exercise_id.clone());
     if *eid_signal.peek() != exercise_id {
         eid_signal.set(exercise_id);
     }
@@ -56,12 +56,12 @@ pub fn PreviousSessions(
             return;
         }
         let offset = sets.read().len() as i64;
-        let eid = *eid_signal.peek();
+        let eid = eid_signal.peek().clone();
         spawn(async move {
             loading.set(true);
             if let Some(db) = state.database() {
                 match db
-                    .get_sets_for_exercise_before(eid, start_of_today_utc_ms(), PAGE_SIZE, offset)
+                    .get_sets_for_exercise_before(&eid, start_of_today_utc_ms(), PAGE_SIZE, offset)
                     .await
                 {
                     Ok(mut new_sets) => {
@@ -100,7 +100,7 @@ pub fn PreviousSessions(
             loading.set(true);
             if let Some(db) = state.database() {
                 match db
-                    .get_sets_for_exercise_before(eid, start_of_today_utc_ms(), PAGE_SIZE, 0)
+                    .get_sets_for_exercise_before(&eid, start_of_today_utc_ms(), PAGE_SIZE, 0)
                     .await
                 {
                     Ok(new_sets) => {

--- a/src/components/settings_view.rs
+++ b/src/components/settings_view.rs
@@ -3,6 +3,13 @@ use crate::models::Settings;
 use crate::state::{SyncStatus, WorkoutState, WorkoutStateManager};
 use crate::sync::SyncCredentials;
 use dioxus::prelude::*;
+use wasm_bindgen::JsValue;
+
+/// Write directly to browser `console.log` — always visible in Playwright
+/// regardless of log level.
+fn js_log(msg: &str) {
+    web_sys::console::log_1(&JsValue::from_str(msg));
+}
 
 /// Clamp and round a value to a given step within [min, max].
 fn clamp_step(value: f64, min: f64, max: f64, step: f64) -> f64 {
@@ -188,9 +195,9 @@ pub fn SettingsView(state: WorkoutState) -> Element {
                                             {
                                                 let state = state;
                                                 spawn(async move {
-                                                    log::info!("[Pairing] Setup complete — triggering initial sync");
+                                                    js_log("[Sync] Initial sync after setup — starting");
                                                     WorkoutStateManager::trigger_background_sync(&state).await;
-                                                    log::info!("[Pairing] Initial sync after setup complete");
+                                                    js_log("[Sync] Initial sync after setup complete");
                                                 });
                                             }
                                         },
@@ -267,9 +274,9 @@ pub fn SettingsView(state: WorkoutState) -> Element {
                                             {
                                                 let state = state;
                                                 spawn(async move {
-                                                    log::info!("[Pairing] Join complete — triggering initial sync");
+                                                    js_log("[Sync] Join complete — triggering initial sync");
                                                     WorkoutStateManager::trigger_background_sync(&state).await;
-                                                    log::info!("[Pairing] Initial sync after pairing complete");
+                                                    js_log("[Sync] Initial sync after pairing complete");
                                                     pairing_step.set(PairingStep::Done);
                                                 });
                                             }

--- a/src/models/exercise.rs
+++ b/src/models/exercise.rs
@@ -26,8 +26,8 @@ pub enum SetTypeConfig {
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 #[allow(dead_code)]
 pub struct ExerciseMetadata {
-    /// Optional database ID for the exercise
-    pub id: Option<i64>,
+    /// Optional database ID for the exercise (UUID string)
+    pub id: Option<String>,
     /// Display name of the exercise (e.g., "Bench Press", "Pull-ups")
     pub name: String,
     /// Configuration for the type of sets this exercise uses
@@ -96,7 +96,7 @@ mod tests {
     #[test]
     fn test_serde_round_trip_weighted_exercise() {
         let original = ExerciseMetadata {
-            id: Some(123),
+            id: Some("test-uuid-123".to_string()),
             name: "Squat".to_string(),
             set_type_config: SetTypeConfig::Weighted {
                 min_weight: 20.0,
@@ -136,7 +136,7 @@ mod tests {
     #[test]
     fn test_exercise_cloning() {
         let original = ExerciseMetadata {
-            id: Some(99),
+            id: Some("test-uuid-99".to_string()),
             name: "Deadlift".to_string(),
             set_type_config: SetTypeConfig::Weighted {
                 min_weight: 20.0,
@@ -155,7 +155,7 @@ mod tests {
     #[test]
     fn test_serde_round_trip_with_rep_range() {
         let original = ExerciseMetadata {
-            id: Some(42),
+            id: Some("test-uuid-42".to_string()),
             name: "Squat".to_string(),
             set_type_config: SetTypeConfig::Weighted {
                 min_weight: 20.0,
@@ -177,7 +177,7 @@ mod tests {
     #[test]
     fn test_serde_defaults_for_missing_rep_fields() {
         // Simulate JSON from older version without rep range fields
-        let json = r#"{"id":1,"name":"Bench","set_type_config":{"Weighted":{"min_weight":20.0,"increment":2.5}}}"#;
+        let json = r#"{"id":"uuid-1","name":"Bench","set_type_config":{"Weighted":{"min_weight":20.0,"increment":2.5}}}"#;
         let deserialized: ExerciseMetadata =
             serde_json::from_str(json).expect("Deserialization failed");
 

--- a/src/models/set.rs
+++ b/src/models/set.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 pub struct HistorySet {
     /// Primary key in completed_sets
     pub id: i64,
-    pub exercise_id: i64,
+    pub exercise_id: String,
     pub exercise_name: String,
     pub set_number: u32,
     pub reps: u32,

--- a/src/state/db.rs
+++ b/src/state/db.rs
@@ -45,10 +45,13 @@ extern "C" {
 
     #[wasm_bindgen(js_name = importDatabase)]
     async fn import_database(file_data: Vec<u8>) -> JsValue;
+
+    #[wasm_bindgen(js_name = ensureCrrTables)]
+    async fn ensure_crr_tables() -> JsValue;
 }
 
 /// Current schema version. Bump this when the schema changes.
-const SCHEMA_VERSION: i64 = 4;
+const SCHEMA_VERSION: i64 = 6;
 
 #[derive(Clone, PartialEq)]
 pub struct Database {
@@ -188,9 +191,33 @@ impl Database {
             self.apply_v4_migration().await?;
         }
 
+        // ── v5 migration: CRR-compatible table schemas ──────────────────────────
+        // crsqlite requires: explicit NOT NULL on PK (AUTOINCREMENT leaves
+        // notnull=0 in pragma table_info), no UNIQUE indices besides PK, and
+        // no CHECK constraints.  Rebuild tables to match the server schema.
+        if current_version < 5 {
+            log::debug!("[DB] Applying v5 migration: CRR-compatible table schemas");
+            self.apply_v5_migration().await?;
+        }
+
+        // ── v6 migration: UUID primary key for exercises ────────────────────────
+        if current_version < 6 {
+            log::debug!("[DB] Applying v6 migration: UUID primary key for exercises");
+            self.apply_v6_migration().await?;
+        }
+
         // Stamp the new version
         self.execute_internal(&format!("PRAGMA user_version = {}", SCHEMA_VERSION), &[])
             .await?;
+
+        // Mark tables as CRRs now that they exist.  applyCrrMigration() in
+        // db-module.js runs during initDatabase() — before Rust creates the
+        // tables — so we must re-run it here.
+        log::debug!("[DB] Ensuring CRR tables are marked after schema migration");
+        let crr_result = ensure_crr_tables().await;
+        if !crr_result.is_truthy() {
+            log::warn!("[DB] ensureCrrTables returned false — CRR marking may have failed");
+        }
 
         Ok(())
     }
@@ -325,14 +352,246 @@ impl Database {
         Ok(())
     }
 
-    /// Inserts the default settings row if no row exists yet.
-    /// Safe to call multiple times — uses INSERT OR IGNORE.
-    async fn seed_settings(&self) -> Result<(), DatabaseError> {
+    /// Rebuild tables to be CRR-compatible:
+    ///   - `INTEGER PRIMARY KEY NOT NULL` (explicit NOT NULL so pragma table_info
+    ///     reports notnull=1, which crsqlite requires)
+    ///   - No UNIQUE indices besides the primary key
+    ///   - No CHECK constraints
+    ///   - No FOREIGN KEY constraints (CRRs manage their own consistency)
+    async fn apply_v5_migration(&self) -> Result<(), DatabaseError> {
+        // ── exercises ───────────────────────────────────────────────────────
         self.execute_internal(
-            "INSERT OR IGNORE INTO settings (id, target_rpe, history_window_days, today_blend_factor) VALUES (1, 8.0, 30, 0.5)",
+            r#"CREATE TABLE IF NOT EXISTS exercises_v5 (
+                id INTEGER PRIMARY KEY NOT NULL,
+                name TEXT NOT NULL DEFAULT '',
+                is_weighted INTEGER NOT NULL DEFAULT 0,
+                min_weight REAL,
+                increment REAL,
+                uuid TEXT NOT NULL DEFAULT '',
+                updated_at INTEGER NOT NULL DEFAULT 0,
+                deleted_at INTEGER,
+                min_reps INTEGER NOT NULL DEFAULT 1,
+                max_reps INTEGER
+            )"#,
             &[],
         )
         .await?;
+        self.execute_internal(
+            "INSERT OR IGNORE INTO exercises_v5 SELECT id, name, is_weighted, min_weight, increment, uuid, updated_at, deleted_at, min_reps, max_reps FROM exercises",
+            &[],
+        )
+        .await?;
+        self.execute_internal("DROP TABLE exercises", &[]).await?;
+        self.execute_internal("ALTER TABLE exercises_v5 RENAME TO exercises", &[])
+            .await?;
+
+        // ── completed_sets ──────────────────────────────────────────────────
+        self.execute_internal(
+            r#"CREATE TABLE IF NOT EXISTS completed_sets_v5 (
+                id INTEGER PRIMARY KEY NOT NULL,
+                exercise_id INTEGER NOT NULL DEFAULT 0,
+                set_number INTEGER NOT NULL DEFAULT 0,
+                reps INTEGER NOT NULL DEFAULT 0,
+                rpe REAL NOT NULL DEFAULT 0.0,
+                weight REAL,
+                is_bodyweight INTEGER NOT NULL DEFAULT 0,
+                recorded_at INTEGER NOT NULL DEFAULT 0,
+                uuid TEXT NOT NULL DEFAULT '',
+                updated_at INTEGER NOT NULL DEFAULT 0,
+                deleted_at INTEGER
+            )"#,
+            &[],
+        )
+        .await?;
+        self.execute_internal(
+            "INSERT OR IGNORE INTO completed_sets_v5 SELECT id, exercise_id, set_number, reps, rpe, weight, is_bodyweight, recorded_at, uuid, updated_at, deleted_at FROM completed_sets",
+            &[],
+        )
+        .await?;
+        self.execute_internal("DROP TABLE completed_sets", &[])
+            .await?;
+        self.execute_internal(
+            "ALTER TABLE completed_sets_v5 RENAME TO completed_sets",
+            &[],
+        )
+        .await?;
+        // Re-create the index (dropped with the old table).
+        self.execute_internal(
+            "CREATE INDEX IF NOT EXISTS idx_sets_exercise_id ON completed_sets(exercise_id)",
+            &[],
+        )
+        .await?;
+
+        // ── settings ────────────────────────────────────────────────────────
+        self.execute_internal(
+            r#"CREATE TABLE IF NOT EXISTS settings_v5 (
+                id INTEGER PRIMARY KEY NOT NULL,
+                target_rpe REAL NOT NULL DEFAULT 8.0,
+                history_window_days INTEGER NOT NULL DEFAULT 30,
+                today_blend_factor REAL NOT NULL DEFAULT 0.5
+            )"#,
+            &[],
+        )
+        .await?;
+        self.execute_internal(
+            "INSERT OR IGNORE INTO settings_v5 SELECT id, target_rpe, history_window_days, today_blend_factor FROM settings",
+            &[],
+        )
+        .await?;
+        self.execute_internal("DROP TABLE settings", &[]).await?;
+        self.execute_internal("ALTER TABLE settings_v5 RENAME TO settings", &[])
+            .await?;
+        // Re-seed in case settings was empty.
+        self.seed_settings().await?;
+
+        log::debug!("[DB] v5 migration complete — tables are now CRR-compatible");
+        Ok(())
+    }
+
+    /// V6: Migrate exercises to UUID primary key for CRR compatibility.
+    ///
+    /// INTEGER PRIMARY KEY causes CRR collisions when two devices independently
+    /// create exercises (both get id=1). Using UUID as PK ensures globally unique
+    /// identifiers.
+    ///
+    /// Also changes completed_sets.exercise_id from INTEGER to TEXT (UUID reference).
+    async fn apply_v6_migration(&self) -> Result<(), DatabaseError> {
+        // Ensure all exercises have a uuid before migration
+        let exercises_without_uuid = self
+            .execute_internal(
+                "SELECT id FROM exercises WHERE uuid = '' OR uuid IS NULL",
+                &[],
+            )
+            .await?;
+        if let Some(arr) = exercises_without_uuid.dyn_ref::<js_sys::Array>() {
+            for i in 0..arr.length() {
+                let row = arr.get(i);
+                let id = js_sys::Reflect::get(&row, &JsValue::from_str("id"))
+                    .ok()
+                    .and_then(|v| v.as_f64());
+                if let Some(id) = id {
+                    let uuid = Self::generate_uuid();
+                    self.execute_internal(
+                        "UPDATE exercises SET uuid = ? WHERE id = ?",
+                        &[JsValue::from_str(&uuid), JsValue::from_f64(id)],
+                    )
+                    .await?;
+                }
+            }
+        }
+
+        // Rebuild exercises with uuid as PRIMARY KEY
+        self.execute_internal(
+            "CREATE TABLE IF NOT EXISTS exercises_v6 (
+                uuid TEXT PRIMARY KEY NOT NULL,
+                name TEXT NOT NULL DEFAULT '',
+                is_weighted INTEGER NOT NULL DEFAULT 0,
+                min_weight REAL,
+                increment REAL,
+                updated_at INTEGER NOT NULL DEFAULT 0,
+                deleted_at INTEGER,
+                min_reps INTEGER NOT NULL DEFAULT 1,
+                max_reps INTEGER
+            )",
+            &[],
+        )
+        .await?;
+        self.execute_internal(
+            "INSERT OR IGNORE INTO exercises_v6 SELECT uuid, name, is_weighted, min_weight, increment, updated_at, deleted_at, min_reps, max_reps FROM exercises",
+            &[],
+        )
+        .await?;
+
+        // Rebuild completed_sets with TEXT exercise_id (uuid reference)
+        self.execute_internal(
+            "CREATE TABLE IF NOT EXISTS completed_sets_v6 (
+                id INTEGER PRIMARY KEY NOT NULL,
+                exercise_id TEXT NOT NULL DEFAULT '',
+                set_number INTEGER NOT NULL DEFAULT 0,
+                reps INTEGER NOT NULL DEFAULT 0,
+                rpe REAL NOT NULL DEFAULT 0.0,
+                weight REAL,
+                is_bodyweight INTEGER NOT NULL DEFAULT 0,
+                recorded_at INTEGER NOT NULL DEFAULT 0,
+                uuid TEXT NOT NULL DEFAULT '',
+                updated_at INTEGER NOT NULL DEFAULT 0,
+                deleted_at INTEGER
+            )",
+            &[],
+        )
+        .await?;
+        // Check for orphaned completed_sets (exercise_id pointing to deleted exercises)
+        let orphan_result = self
+            .execute_internal(
+                "SELECT count(*) as cnt FROM completed_sets cs WHERE NOT EXISTS (SELECT 1 FROM exercises e WHERE e.id = cs.exercise_id)",
+                &[],
+            )
+            .await;
+        if let Ok(ref v) = orphan_result
+            && let Some(arr) = v.dyn_ref::<js_sys::Array>()
+            && arr.length() > 0
+        {
+            let cnt = js_sys::Reflect::get(&arr.get(0), &JsValue::from_str("cnt"))
+                .ok()
+                .and_then(|v| v.as_f64())
+                .unwrap_or(0.0);
+            if cnt > 0.0 {
+                #[cfg(target_arch = "wasm32")]
+                web_sys::console::warn_1(&JsValue::from_str(&format!(
+                    "[DB] v6 migration: {} orphaned completed_sets rows will lose exercise linkage",
+                    cnt
+                )));
+            }
+        }
+
+        self.execute_internal(
+            "INSERT OR IGNORE INTO completed_sets_v6 SELECT cs.id, e.uuid, cs.set_number, cs.reps, cs.rpe, cs.weight, cs.is_bodyweight, cs.recorded_at, cs.uuid, cs.updated_at, cs.deleted_at FROM completed_sets cs INNER JOIN exercises e ON cs.exercise_id = e.id",
+            &[],
+        )
+        .await?;
+
+        // Drop old tables and rename
+        self.execute_internal("DROP TABLE IF EXISTS completed_sets", &[])
+            .await?;
+        self.execute_internal("DROP TABLE IF EXISTS exercises", &[])
+            .await?;
+        self.execute_internal("ALTER TABLE exercises_v6 RENAME TO exercises", &[])
+            .await?;
+        self.execute_internal(
+            "ALTER TABLE completed_sets_v6 RENAME TO completed_sets",
+            &[],
+        )
+        .await?;
+
+        // Recreate index
+        self.execute_internal(
+            "CREATE INDEX IF NOT EXISTS idx_sets_exercise_id ON completed_sets(exercise_id)",
+            &[],
+        )
+        .await?;
+
+        log::debug!("[DB] v6 migration complete — exercises now use UUID primary key");
+        Ok(())
+    }
+
+    /// Inserts the default settings row if no row exists yet.
+    /// Uses a SELECT guard instead of INSERT OR IGNORE because CRR tables
+    /// don't support ON CONFLICT clauses.
+    async fn seed_settings(&self) -> Result<(), DatabaseError> {
+        let existing = self
+            .execute_internal("SELECT id FROM settings WHERE id = 1", &[])
+            .await?;
+        let has_row = existing
+            .dyn_ref::<js_sys::Array>()
+            .map(|a| a.length() > 0)
+            .unwrap_or(false);
+        if !has_row {
+            self.execute_internal(
+                "INSERT INTO settings (id, target_rpe, history_window_days, today_blend_factor) VALUES (1, 8.0, 30, 0.5)",
+                &[],
+            )
+            .await?;
+        }
         Ok(())
     }
 
@@ -434,7 +693,7 @@ impl Database {
     /// Log a single set for the given exercise. Records the current timestamp.
     pub async fn log_set(
         &self,
-        exercise_id: i64,
+        exercise_id: &str,
         set: &CompletedSet,
     ) -> Result<i64, DatabaseError> {
         let (weight, is_bodyweight) = match set.set_type {
@@ -452,7 +711,7 @@ impl Database {
         "#;
 
         let params = vec![
-            JsValue::from_f64(exercise_id as f64),
+            JsValue::from_str(exercise_id),
             JsValue::from_f64(set.set_number as f64),
             JsValue::from_f64(set.reps as f64),
             JsValue::from_f64(set.rpe as f64),
@@ -473,7 +732,7 @@ impl Database {
     /// data-import scenarios where the recording time is known.
     pub async fn log_set_at(
         &self,
-        exercise_id: i64,
+        exercise_id: &str,
         set: &CompletedSet,
         recorded_at: f64,
     ) -> Result<i64, DatabaseError> {
@@ -492,7 +751,7 @@ impl Database {
         "#;
 
         let params = vec![
-            JsValue::from_f64(exercise_id as f64),
+            JsValue::from_str(exercise_id),
             JsValue::from_f64(set.set_number as f64),
             JsValue::from_f64(set.reps as f64),
             JsValue::from_f64(set.rpe as f64),
@@ -512,7 +771,7 @@ impl Database {
     /// Returns sets for one exercise in reverse-chronological order with pagination.
     pub async fn get_sets_for_exercise(
         &self,
-        exercise_id: i64,
+        exercise_id: &str,
         limit: i64,
         offset: i64,
     ) -> Result<Vec<HistorySet>, DatabaseError> {
@@ -520,14 +779,14 @@ impl Database {
             SELECT cs.id, cs.exercise_id, e.name AS exercise_name,
                    cs.set_number, cs.reps, cs.rpe, cs.weight, cs.is_bodyweight, cs.recorded_at
             FROM completed_sets cs
-            JOIN exercises e ON cs.exercise_id = e.id
+            JOIN exercises e ON cs.exercise_id = e.uuid
             WHERE cs.exercise_id = ? AND cs.deleted_at IS NULL
             ORDER BY cs.recorded_at DESC, cs.id DESC
             LIMIT ? OFFSET ?
         "#;
 
         let params = vec![
-            JsValue::from_f64(exercise_id as f64),
+            JsValue::from_str(exercise_id),
             JsValue::from_f64(limit as f64),
             JsValue::from_f64(offset as f64),
         ];
@@ -543,7 +802,7 @@ impl Database {
     /// current (today's) session are not shown alongside historical data.
     pub async fn get_sets_for_exercise_before(
         &self,
-        exercise_id: i64,
+        exercise_id: &str,
         before_ms: f64,
         limit: i64,
         offset: i64,
@@ -552,14 +811,14 @@ impl Database {
             SELECT cs.id, cs.exercise_id, e.name AS exercise_name,
                    cs.set_number, cs.reps, cs.rpe, cs.weight, cs.is_bodyweight, cs.recorded_at
             FROM completed_sets cs
-            JOIN exercises e ON cs.exercise_id = e.id
+            JOIN exercises e ON cs.exercise_id = e.uuid
             WHERE cs.exercise_id = ? AND cs.recorded_at < ? AND cs.deleted_at IS NULL
             ORDER BY cs.recorded_at DESC, cs.id DESC
             LIMIT ? OFFSET ?
         "#;
 
         let params = vec![
-            JsValue::from_f64(exercise_id as f64),
+            JsValue::from_str(exercise_id),
             JsValue::from_f64(before_ms),
             JsValue::from_f64(limit as f64),
             JsValue::from_f64(offset as f64),
@@ -579,7 +838,7 @@ impl Database {
             SELECT cs.id, cs.exercise_id, e.name AS exercise_name,
                    cs.set_number, cs.reps, cs.rpe, cs.weight, cs.is_bodyweight, cs.recorded_at
             FROM completed_sets cs
-            JOIN exercises e ON cs.exercise_id = e.id
+            JOIN exercises e ON cs.exercise_id = e.uuid
             WHERE cs.deleted_at IS NULL
             ORDER BY cs.recorded_at DESC, cs.id DESC
             LIMIT ? OFFSET ?
@@ -644,7 +903,10 @@ impl Database {
         Ok(())
     }
 
-    pub async fn save_exercise(&self, exercise: &ExerciseMetadata) -> Result<i64, DatabaseError> {
+    pub async fn save_exercise(
+        &self,
+        exercise: &ExerciseMetadata,
+    ) -> Result<String, DatabaseError> {
         let (is_weighted, min_weight, increment) = match exercise.set_type_config {
             crate::models::SetTypeConfig::Weighted {
                 min_weight,
@@ -660,11 +922,11 @@ impl Database {
             .map(|r| JsValue::from_f64(r as f64))
             .unwrap_or(JsValue::NULL);
 
-        let result = if let Some(id) = exercise.id {
+        let result = if let Some(ref id) = exercise.id {
             let sql = r#"
                 UPDATE exercises SET name = ?, is_weighted = ?, min_weight = ?, increment = ?, min_reps = ?, max_reps = ?, updated_at = ?
-                WHERE id = ?
-                RETURNING id
+                WHERE uuid = ?
+                RETURNING uuid
             "#;
             let params = vec![
                 JsValue::from_str(&exercise.name),
@@ -678,38 +940,72 @@ impl Database {
                 min_reps_val,
                 max_reps_val,
                 JsValue::from_f64(now),
-                JsValue::from_f64(id as f64),
+                JsValue::from_str(id),
             ];
             self.execute(sql, &params).await?
         } else {
-            let uuid = Self::generate_uuid();
-            let sql = r#"
-                INSERT INTO exercises (name, is_weighted, min_weight, increment, min_reps, max_reps, uuid, updated_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-                ON CONFLICT(name) DO UPDATE SET
-                    is_weighted = excluded.is_weighted,
-                    min_weight = excluded.min_weight,
-                    increment = excluded.increment,
-                    min_reps = excluded.min_reps,
-                    max_reps = excluded.max_reps,
-                    updated_at = excluded.updated_at
-                RETURNING id
-            "#;
-            let params = vec![
-                JsValue::from_str(&exercise.name),
-                JsValue::from_bool(is_weighted),
-                min_weight
-                    .map(|w| JsValue::from_f64(w as f64))
-                    .unwrap_or(JsValue::NULL),
-                increment
-                    .map(|i| JsValue::from_f64(i as f64))
-                    .unwrap_or(JsValue::NULL),
-                min_reps_val,
-                max_reps_val,
-                JsValue::from_str(&uuid),
-                JsValue::from_f64(now),
-            ];
-            self.execute(sql, &params).await?
+            // Check if an exercise with this name already exists.
+            // CRR tables don't support UNIQUE constraints or ON CONFLICT
+            // clauses, so we check-then-upsert manually.
+            let existing = self
+                .execute(
+                    "SELECT uuid FROM exercises WHERE name = ?",
+                    &[JsValue::from_str(&exercise.name)],
+                )
+                .await?;
+            let existing_uuid = existing
+                .dyn_ref::<js_sys::Array>()
+                .and_then(|a| if a.length() > 0 { Some(a.get(0)) } else { None })
+                .and_then(|row| {
+                    js_sys::Reflect::get(&row, &JsValue::from_str("uuid"))
+                        .ok()
+                        .and_then(|v| v.as_string())
+                });
+
+            if let Some(euuid) = existing_uuid {
+                // Update existing exercise by name match.
+                let sql = r#"
+                    UPDATE exercises SET is_weighted = ?, min_weight = ?, increment = ?, min_reps = ?, max_reps = ?, updated_at = ?
+                    WHERE uuid = ?
+                    RETURNING uuid
+                "#;
+                let params = vec![
+                    JsValue::from_bool(is_weighted),
+                    min_weight
+                        .map(|w| JsValue::from_f64(w as f64))
+                        .unwrap_or(JsValue::NULL),
+                    increment
+                        .map(|i| JsValue::from_f64(i as f64))
+                        .unwrap_or(JsValue::NULL),
+                    min_reps_val,
+                    max_reps_val,
+                    JsValue::from_f64(now),
+                    JsValue::from_str(&euuid),
+                ];
+                self.execute(sql, &params).await?
+            } else {
+                let uuid = Self::generate_uuid();
+                let sql = r#"
+                    INSERT INTO exercises (uuid, name, is_weighted, min_weight, increment, min_reps, max_reps, updated_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    RETURNING uuid
+                "#;
+                let params = vec![
+                    JsValue::from_str(&uuid),
+                    JsValue::from_str(&exercise.name),
+                    JsValue::from_bool(is_weighted),
+                    min_weight
+                        .map(|w| JsValue::from_f64(w as f64))
+                        .unwrap_or(JsValue::NULL),
+                    increment
+                        .map(|i| JsValue::from_f64(i as f64))
+                        .unwrap_or(JsValue::NULL),
+                    min_reps_val,
+                    max_reps_val,
+                    JsValue::from_f64(now),
+                ];
+                self.execute(sql, &params).await?
+            }
         };
 
         let array = result
@@ -724,16 +1020,15 @@ impl Database {
         }
 
         let first_row = array.get(0);
-        let id = js_sys::Reflect::get(&first_row, &JsValue::from_str("id"))?
-            .as_f64()
-            .ok_or_else(|| DatabaseError::QueryError("Failed to get exercise id".to_string()))?
-            as i64;
+        let id = js_sys::Reflect::get(&first_row, &JsValue::from_str("uuid"))?
+            .as_string()
+            .ok_or_else(|| DatabaseError::QueryError("Failed to get exercise uuid".to_string()))?;
 
         Ok(id)
     }
 
     pub async fn get_exercises(&self) -> Result<Vec<ExerciseMetadata>, DatabaseError> {
-        let sql = "SELECT id, name, is_weighted, min_weight, increment, min_reps, max_reps FROM exercises WHERE deleted_at IS NULL ORDER BY name";
+        let sql = "SELECT uuid, name, is_weighted, min_weight, increment, min_reps, max_reps FROM exercises WHERE deleted_at IS NULL ORDER BY name";
         let result = self.execute(sql, &[]).await?;
 
         let array = result
@@ -743,9 +1038,7 @@ impl Database {
         let mut exercises = Vec::new();
         for i in 0..array.length() {
             let row = array.get(i);
-            let id = js_sys::Reflect::get(&row, &JsValue::from_str("id"))?
-                .as_f64()
-                .map(|f| f as i64);
+            let id = js_sys::Reflect::get(&row, &JsValue::from_str("uuid"))?.as_string();
 
             let name = js_sys::Reflect::get(&row, &JsValue::from_str("name"))?
                 .as_string()
@@ -861,7 +1154,7 @@ impl Database {
     /// Returns the most recent set for the given exercise (used for predictions).
     pub async fn get_last_set_for_exercise(
         &self,
-        exercise_id: i64,
+        exercise_id: &str,
     ) -> Result<Option<crate::models::CompletedSet>, DatabaseError> {
         let sql = r#"
             SELECT set_number, reps, rpe, weight, is_bodyweight
@@ -871,7 +1164,7 @@ impl Database {
             LIMIT 1
         "#;
 
-        let params = vec![JsValue::from_f64(exercise_id as f64)];
+        let params = vec![JsValue::from_str(exercise_id)];
         let result = self.execute(sql, &params).await?;
 
         let array = result
@@ -928,7 +1221,7 @@ impl Database {
     /// Bodyweight sets are skipped because e1RM is undefined without a weight.
     pub async fn get_best_set_for_exercise(
         &self,
-        exercise_id: i64,
+        exercise_id: &str,
         since_ms: f64,
         exclude_start_ms: f64,
         exclude_end_ms: f64,
@@ -944,7 +1237,7 @@ impl Database {
         "#;
 
         let params = vec![
-            JsValue::from_f64(exercise_id as f64),
+            JsValue::from_str(exercise_id),
             JsValue::from_f64(since_ms),
             JsValue::from_f64(exclude_start_ms),
             JsValue::from_f64(exclude_end_ms),
@@ -981,7 +1274,7 @@ impl Database {
     /// Returns `None` when no sets were logged today for this exercise.
     pub async fn get_latest_set_today(
         &self,
-        exercise_id: i64,
+        exercise_id: &str,
         today_start_ms: f64,
         today_end_ms: f64,
     ) -> Result<Option<CompletedSet>, DatabaseError> {
@@ -997,7 +1290,7 @@ impl Database {
         "#;
 
         let params = vec![
-            JsValue::from_f64(exercise_id as f64),
+            JsValue::from_str(exercise_id),
             JsValue::from_f64(today_start_ms),
             JsValue::from_f64(today_end_ms),
         ];
@@ -1130,9 +1423,8 @@ impl Database {
                 as i64;
 
             let exercise_id = js_sys::Reflect::get(&row, &JsValue::from_str("exercise_id"))?
-                .as_f64()
-                .ok_or_else(|| DatabaseError::QueryError("Failed to get exercise_id".to_string()))?
-                as i64;
+                .as_string()
+                .unwrap_or_default();
 
             let exercise_name = js_sys::Reflect::get(&row, &JsValue::from_str("exercise_name"))?
                 .as_string()

--- a/src/state/db_tests.rs
+++ b/src/state/db_tests.rs
@@ -119,10 +119,10 @@ mod workout_state_manager_tests {
             .iter()
             .find(|e| e.name == "Bench Press")
             .expect("Bench Press exercise must exist in DB");
-        let bench_id = bench.id.expect("Bench Press must have an id");
+        let bench_id = bench.id.clone().expect("Bench Press must have an id");
 
         let persisted_sets = db
-            .get_sets_for_exercise(bench_id, 10, 0)
+            .get_sets_for_exercise(&bench_id, 10, 0)
             .await
             .expect("get_sets_for_exercise failed");
 
@@ -244,7 +244,10 @@ async fn test_log_set_weighted() {
         set_type: SetType::Weighted { weight: 135.0 },
     };
 
-    let set_id = db.log_set(exercise_id, &set).await.expect("log_set failed");
+    let set_id = db
+        .log_set(&exercise_id, &set)
+        .await
+        .expect("log_set failed");
 
     assert!(set_id > 0, "Set ID should be positive");
 }
@@ -275,7 +278,7 @@ async fn test_log_set_bodyweight() {
     };
 
     let set_id = db
-        .log_set(exercise_id, &set)
+        .log_set(&exercise_id, &set)
         .await
         .expect("log_set bodyweight failed");
 
@@ -314,19 +317,21 @@ async fn test_get_sets_for_exercise_pagination() {
                 weight: 60.0 + (i as f32 * 5.0),
             },
         };
-        db.log_set(exercise_id, &set).await.expect("log_set failed");
+        db.log_set(&exercise_id, &set)
+            .await
+            .expect("log_set failed");
     }
 
     // Page 1: first 2 results (most recent first)
     let page1 = db
-        .get_sets_for_exercise(exercise_id, 2, 0)
+        .get_sets_for_exercise(&exercise_id, 2, 0)
         .await
         .expect("get_sets_for_exercise failed");
     assert_eq!(page1.len(), 2, "Page 1 should have 2 results");
 
     // Page 2: remaining 1 result
     let page2 = db
-        .get_sets_for_exercise(exercise_id, 2, 2)
+        .get_sets_for_exercise(&exercise_id, 2, 2)
         .await
         .expect("get_sets_for_exercise page 2 failed");
     assert_eq!(page2.len(), 1, "Page 2 should have 1 result");
@@ -374,7 +379,7 @@ async fn test_get_sets_for_exercise_isolation() {
     let id_b = db.save_exercise(&ex_b).await.expect("Save B failed");
 
     db.log_set(
-        id_a,
+        &id_a,
         &CompletedSet {
             set_number: 1,
             reps: 5,
@@ -385,7 +390,7 @@ async fn test_get_sets_for_exercise_isolation() {
     .await
     .expect("log set A failed");
     db.log_set(
-        id_b,
+        &id_b,
         &CompletedSet {
             set_number: 1,
             reps: 3,
@@ -397,11 +402,11 @@ async fn test_get_sets_for_exercise_isolation() {
     .expect("log set B failed");
 
     let sets_a = db
-        .get_sets_for_exercise(id_a, 10, 0)
+        .get_sets_for_exercise(&id_a, 10, 0)
         .await
         .expect("query A failed");
     assert_eq!(sets_a.len(), 1);
-    assert_eq!(sets_a[0].exercise_id, id_a);
+    assert_eq!(sets_a[0].exercise_id, id_a, "exercise_id should match");
     assert_eq!(sets_a[0].reps, 5);
 }
 
@@ -449,15 +454,15 @@ async fn test_get_sets_for_exercise_before_excludes_today() {
         set_type: SetType::Weighted { weight: 110.0 },
     };
 
-    db.log_set_at(exercise_id, &yesterday_set, yesterday_ms)
+    db.log_set_at(&exercise_id, &yesterday_set, yesterday_ms)
         .await
         .expect("log yesterday set failed");
-    db.log_set(exercise_id, &today_set)
+    db.log_set(&exercise_id, &today_set)
         .await
         .expect("log today set failed");
 
     let results = db
-        .get_sets_for_exercise_before(exercise_id, start_of_today_utc, 10, 0)
+        .get_sets_for_exercise_before(&exercise_id, start_of_today_utc, 10, 0)
         .await
         .expect("get_sets_for_exercise_before failed");
 
@@ -494,7 +499,7 @@ async fn test_get_all_sets_paginated() {
     let id2 = db.save_exercise(&ex2).await.expect("Save 2 failed");
 
     db.log_set(
-        id1,
+        &id1,
         &CompletedSet {
             set_number: 1,
             reps: 10,
@@ -505,7 +510,7 @@ async fn test_get_all_sets_paginated() {
     .await
     .expect("log 1 failed");
     db.log_set(
-        id2,
+        &id2,
         &CompletedSet {
             set_number: 1,
             reps: 8,
@@ -523,8 +528,8 @@ async fn test_get_all_sets_paginated() {
 
     assert_eq!(all.len(), 2, "Should return 2 sets total");
     // Most recently logged should come first
-    assert_eq!(all[0].exercise_id, id2);
-    assert_eq!(all[1].exercise_id, id1);
+    assert_eq!(all[0].exercise_id, id2, "Most recent should be exercise 2");
+    assert_eq!(all[1].exercise_id, id1, "Second should be exercise 1");
 }
 
 /// RED: update_set persists changes; subsequent reads reflect the update.
@@ -554,7 +559,10 @@ async fn test_update_set() {
         rpe: 7.0,
         set_type: SetType::Weighted { weight: 50.0 },
     };
-    let set_id = db.log_set(exercise_id, &set).await.expect("log_set failed");
+    let set_id = db
+        .log_set(&exercise_id, &set)
+        .await
+        .expect("log_set failed");
 
     // Update: change reps to 10, rpe to 8.0, weight to 55.0 (keep same recorded_at)
     let original_recorded_at = 1_700_000_000_000.0_f64;
@@ -563,7 +571,7 @@ async fn test_update_set() {
         .expect("update_set failed");
 
     let updated = db
-        .get_sets_for_exercise(exercise_id, 1, 0)
+        .get_sets_for_exercise(&exercise_id, 1, 0)
         .await
         .expect("read after update failed");
 
@@ -607,7 +615,7 @@ async fn test_update_set_recorded_at() {
         set_type: SetType::Weighted { weight: 100.0 },
     };
     let set_id = db
-        .log_set_at(exercise_id, &set, yesterday_ms)
+        .log_set_at(&exercise_id, &set, yesterday_ms)
         .await
         .expect("log_set_at failed");
 
@@ -618,7 +626,7 @@ async fn test_update_set_recorded_at() {
         .expect("update_set failed");
 
     let updated = db
-        .get_sets_for_exercise(exercise_id, 1, 0)
+        .get_sets_for_exercise(&exercise_id, 1, 0)
         .await
         .expect("read after update failed");
 
@@ -652,7 +660,7 @@ async fn test_delete_set() {
 
     let set_id = db
         .log_set(
-            exercise_id,
+            &exercise_id,
             &CompletedSet {
                 set_number: 1,
                 reps: 8,
@@ -666,7 +674,7 @@ async fn test_delete_set() {
     db.delete_set(set_id).await.expect("delete_set failed");
 
     let remaining = db
-        .get_sets_for_exercise(exercise_id, 10, 0)
+        .get_sets_for_exercise(&exercise_id, 10, 0)
         .await
         .expect("read after delete failed");
 
@@ -696,7 +704,7 @@ async fn test_get_last_set_for_exercise_new_schema() {
 
     // Log two sets — most recent should be returned
     db.log_set(
-        exercise_id,
+        &exercise_id,
         &CompletedSet {
             set_number: 1,
             reps: 8,
@@ -708,7 +716,7 @@ async fn test_get_last_set_for_exercise_new_schema() {
     .expect("log set 1 failed");
 
     db.log_set(
-        exercise_id,
+        &exercise_id,
         &CompletedSet {
             set_number: 2,
             reps: 5,
@@ -720,7 +728,7 @@ async fn test_get_last_set_for_exercise_new_schema() {
     .expect("log set 2 failed");
 
     let last = db
-        .get_last_set_for_exercise(exercise_id)
+        .get_last_set_for_exercise(&exercise_id)
         .await
         .expect("get_last_set_for_exercise failed");
 
@@ -768,9 +776,9 @@ async fn test_save_exercise() {
     assert!(result.is_ok(), "Save exercise should succeed");
     let inserted_id = result.unwrap();
 
-    // Test explicit UPDATE WHERE id = ?
+    // Test explicit UPDATE WHERE uuid = ?
     let updated_exercise_with_id = ExerciseMetadata {
-        id: Some(inserted_id),
+        id: Some(inserted_id.clone()),
         name: "Deadlift Modified".to_string(),
         set_type_config: SetTypeConfig::Weighted {
             min_weight: 145.0,
@@ -913,7 +921,7 @@ async fn test_export_import_round_trip() {
         rpe: 7.5,
         set_type: SetType::Weighted { weight: 135.0 },
     };
-    db1.log_set(exercise_id, &set)
+    db1.log_set(&exercise_id, &set)
         .await
         .expect("log_set failed");
 
@@ -942,7 +950,7 @@ async fn test_export_import_round_trip() {
     // Verify we can log another set in the imported database
     let new_set_id = db2
         .log_set(
-            exercise_id,
+            &exercise_id,
             &CompletedSet {
                 set_number: 2,
                 reps: 6,
@@ -1092,8 +1100,8 @@ async fn test_new_exercise_has_uuid() {
 
     let result = db
         .execute(
-            "SELECT uuid, updated_at FROM exercises WHERE id = ?",
-            &[wasm_bindgen::JsValue::from_f64(exercise_id as f64)],
+            "SELECT uuid, updated_at FROM exercises WHERE uuid = ?",
+            &[wasm_bindgen::JsValue::from_str(&exercise_id)],
         )
         .await
         .expect("Query failed");
@@ -1150,7 +1158,10 @@ async fn test_new_set_has_uuid_and_updated_at() {
         rpe: 7.5,
         set_type: SetType::Weighted { weight: 80.0 },
     };
-    let set_id = db.log_set(exercise_id, &set).await.expect("log_set failed");
+    let set_id = db
+        .log_set(&exercise_id, &set)
+        .await
+        .expect("log_set failed");
 
     let result = db
         .execute(
@@ -1205,7 +1216,7 @@ async fn test_update_set_updates_updated_at() {
 
     let set_id = db
         .log_set(
-            exercise_id,
+            &exercise_id,
             &CompletedSet {
                 set_number: 1,
                 reps: 8,
@@ -1291,7 +1302,7 @@ async fn test_delete_set_is_soft_delete() {
 
     let set_id = db
         .log_set(
-            exercise_id,
+            &exercise_id,
             &CompletedSet {
                 set_number: 1,
                 reps: 8,
@@ -1333,7 +1344,7 @@ async fn test_delete_set_is_soft_delete() {
 
     // The set must not appear in normal queries.
     let visible = db
-        .get_sets_for_exercise(exercise_id, 10, 0)
+        .get_sets_for_exercise(&exercise_id, 10, 0)
         .await
         .expect("get_sets_for_exercise failed");
     assert_eq!(
@@ -1368,7 +1379,7 @@ async fn test_uuids_are_unique_across_records() {
 
     let id1 = db
         .log_set(
-            exercise_id,
+            &exercise_id,
             &CompletedSet {
                 set_number: 1,
                 reps: 5,
@@ -1380,7 +1391,7 @@ async fn test_uuids_are_unique_across_records() {
         .expect("log set 1 failed");
     let id2 = db
         .log_set(
-            exercise_id,
+            &exercise_id,
             &CompletedSet {
                 set_number: 2,
                 reps: 5,
@@ -1446,8 +1457,8 @@ async fn test_edit_exercise_updates_updated_at() {
     // Read the initial updated_at
     let before_result = db
         .execute(
-            "SELECT updated_at FROM exercises WHERE id = ?",
-            &[wasm_bindgen::JsValue::from_f64(exercise_id as f64)],
+            "SELECT updated_at FROM exercises WHERE uuid = ?",
+            &[wasm_bindgen::JsValue::from_str(&exercise_id)],
         )
         .await
         .expect("SELECT before failed");
@@ -1461,7 +1472,7 @@ async fn test_edit_exercise_updates_updated_at() {
 
     // Update the exercise
     let updated = ExerciseMetadata {
-        id: Some(exercise_id),
+        id: Some(exercise_id.clone()),
         name: "Squat".to_string(),
         set_type_config: SetTypeConfig::Weighted {
             min_weight: 20.0,
@@ -1474,8 +1485,8 @@ async fn test_edit_exercise_updates_updated_at() {
 
     let after_result = db
         .execute(
-            "SELECT updated_at FROM exercises WHERE id = ?",
-            &[wasm_bindgen::JsValue::from_f64(exercise_id as f64)],
+            "SELECT updated_at FROM exercises WHERE uuid = ?",
+            &[wasm_bindgen::JsValue::from_str(&exercise_id)],
         )
         .await
         .expect("SELECT after failed");
@@ -1501,7 +1512,7 @@ async fn test_edit_exercise_updates_updated_at() {
 // ── History query tests for e1RM calculation (#131) ─────────────────────────
 
 /// Helper: creates a fresh DB with a weighted exercise and returns (db, exercise_id).
-async fn setup_exercise_for_history() -> (Database, i64) {
+async fn setup_exercise_for_history() -> (Database, String) {
     let mut db = Database::new();
     db.init(None).await.expect("DB init failed");
 
@@ -1542,7 +1553,7 @@ async fn test_best_set_returns_highest_e1rm() {
         rpe: 8.0,
         set_type: SetType::Weighted { weight: 100.0 },
     };
-    db.log_set_at(eid, &set_a, day(3) + 1000.0)
+    db.log_set_at(&eid, &set_a, day(3) + 1000.0)
         .await
         .expect("log A");
 
@@ -1553,7 +1564,7 @@ async fn test_best_set_returns_highest_e1rm() {
         rpe: 9.0,
         set_type: SetType::Weighted { weight: 120.0 },
     };
-    db.log_set_at(eid, &set_b, day(5) + 1000.0)
+    db.log_set_at(&eid, &set_b, day(5) + 1000.0)
         .await
         .expect("log B");
 
@@ -1564,12 +1575,12 @@ async fn test_best_set_returns_highest_e1rm() {
         rpe: 7.0,
         set_type: SetType::Weighted { weight: 80.0 },
     };
-    db.log_set_at(eid, &set_c, day(7) + 1000.0)
+    db.log_set_at(&eid, &set_c, day(7) + 1000.0)
         .await
         .expect("log C");
 
     let best = db
-        .get_best_set_for_exercise(eid, day(0), today_start, today_end)
+        .get_best_set_for_exercise(&eid, day(0), today_start, today_end)
         .await
         .expect("query failed");
 
@@ -1600,7 +1611,7 @@ async fn test_best_set_excludes_today() {
         rpe: 10.0,
         set_type: SetType::Weighted { weight: 200.0 },
     };
-    db.log_set_at(eid, &set_today, today_start + 5000.0)
+    db.log_set_at(&eid, &set_today, today_start + 5000.0)
         .await
         .expect("log today");
 
@@ -1611,12 +1622,12 @@ async fn test_best_set_excludes_today() {
         rpe: 8.0,
         set_type: SetType::Weighted { weight: 100.0 },
     };
-    db.log_set_at(eid, &set_history, day(5) + 1000.0)
+    db.log_set_at(&eid, &set_history, day(5) + 1000.0)
         .await
         .expect("log history");
 
     let best = db
-        .get_best_set_for_exercise(eid, day(0), today_start, today_end)
+        .get_best_set_for_exercise(&eid, day(0), today_start, today_end)
         .await
         .expect("query failed");
 
@@ -1638,7 +1649,7 @@ async fn test_best_set_empty_history() {
     let day = |d: i64| d as f64 * MS_PER_DAY;
 
     let best = db
-        .get_best_set_for_exercise(eid, day(0), day(10), day(11))
+        .get_best_set_for_exercise(&eid, day(0), day(10), day(11))
         .await
         .expect("query failed");
 
@@ -1661,12 +1672,12 @@ async fn test_best_set_all_sets_today() {
         rpe: 8.0,
         set_type: SetType::Weighted { weight: 100.0 },
     };
-    db.log_set_at(eid, &set, today_start + 1000.0)
+    db.log_set_at(&eid, &set, today_start + 1000.0)
         .await
         .expect("log");
 
     let best = db
-        .get_best_set_for_exercise(eid, day(0), today_start, today_end)
+        .get_best_set_for_exercise(&eid, day(0), today_start, today_end)
         .await
         .expect("query failed");
 
@@ -1687,7 +1698,7 @@ async fn test_best_set_respects_since_date() {
         rpe: 10.0,
         set_type: SetType::Weighted { weight: 200.0 },
     };
-    db.log_set_at(eid, &old_set, day(2) + 1000.0)
+    db.log_set_at(&eid, &old_set, day(2) + 1000.0)
         .await
         .expect("log old");
 
@@ -1698,13 +1709,13 @@ async fn test_best_set_respects_since_date() {
         rpe: 8.0,
         set_type: SetType::Weighted { weight: 100.0 },
     };
-    db.log_set_at(eid, &recent_set, day(8) + 1000.0)
+    db.log_set_at(&eid, &recent_set, day(8) + 1000.0)
         .await
         .expect("log recent");
 
     // Window starts at day 5, so old_set (day 2) is excluded
     let best = db
-        .get_best_set_for_exercise(eid, day(5), day(10), day(11))
+        .get_best_set_for_exercise(&eid, day(5), day(10), day(11))
         .await
         .expect("query failed");
 
@@ -1729,7 +1740,7 @@ async fn test_latest_set_today_returns_most_recent() {
         rpe: 7.0,
         set_type: SetType::Weighted { weight: 80.0 },
     };
-    db.log_set_at(eid, &set_early, today_start + 1000.0)
+    db.log_set_at(&eid, &set_early, today_start + 1000.0)
         .await
         .expect("log early");
 
@@ -1740,12 +1751,12 @@ async fn test_latest_set_today_returns_most_recent() {
         rpe: 9.0,
         set_type: SetType::Weighted { weight: 100.0 },
     };
-    db.log_set_at(eid, &set_late, today_start + 5000.0)
+    db.log_set_at(&eid, &set_late, today_start + 5000.0)
         .await
         .expect("log late");
 
     let latest = db
-        .get_latest_set_today(eid, today_start, today_end)
+        .get_latest_set_today(&eid, today_start, today_end)
         .await
         .expect("query failed");
 
@@ -1763,7 +1774,7 @@ async fn test_latest_set_today_none_when_empty() {
     let day = |d: i64| d as f64 * MS_PER_DAY;
 
     let latest = db
-        .get_latest_set_today(eid, day(10), day(11))
+        .get_latest_set_today(&eid, day(10), day(11))
         .await
         .expect("query failed");
 
@@ -1786,12 +1797,12 @@ async fn test_latest_set_today_ignores_other_days() {
         rpe: 8.0,
         set_type: SetType::Weighted { weight: 100.0 },
     };
-    db.log_set_at(eid, &yesterday_set, day(9) + 5000.0)
+    db.log_set_at(&eid, &yesterday_set, day(9) + 5000.0)
         .await
         .expect("log yesterday");
 
     let latest = db
-        .get_latest_set_today(eid, today_start, today_end)
+        .get_latest_set_today(&eid, today_start, today_end)
         .await
         .expect("query failed");
 

--- a/src/state/workout_state.rs
+++ b/src/state/workout_state.rs
@@ -29,7 +29,7 @@ pub struct PredictedParameters {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct WorkoutSession {
-    pub session_id: Option<i64>,
+    pub session_id: Option<String>,
     pub exercise: ExerciseMetadata,
     pub completed_sets: Vec<CompletedSet>,
     pub predicted: PredictedParameters,
@@ -309,7 +309,7 @@ impl WorkoutStateManager {
     pub async fn save_exercise(
         state: &WorkoutState,
         exercise: ExerciseMetadata,
-    ) -> Result<i64, WorkoutError> {
+    ) -> Result<String, WorkoutError> {
         let db = state.database().ok_or(WorkoutError::NotInitialized)?;
 
         let id = db
@@ -351,12 +351,12 @@ impl WorkoutStateManager {
             .map_err(|e: crate::state::DatabaseError| {
                 WorkoutError::SaveExerciseError(e.to_string())
             })?;
-        exercise.id = Some(id);
+        exercise.id = Some(id.clone());
 
         // Fetch last set for suggestions (only for weighted exercises)
         let last_set = match exercise.set_type_config {
             crate::models::SetTypeConfig::Weighted { .. } => {
-                db.get_last_set_for_exercise(id).await.unwrap_or_else(|e| {
+                db.get_last_set_for_exercise(&id).await.unwrap_or_else(|e| {
                     log::warn!("Failed to fetch last set for suggestion: {}", e);
                     None
                 })
@@ -373,7 +373,7 @@ impl WorkoutStateManager {
 
         // Use exercise_id as session_id so the UI can detect a new session started
         let session = WorkoutSession {
-            session_id: exercise.id,
+            session_id: exercise.id.clone(),
             exercise,
             completed_sets: Vec::new(),
             predicted,
@@ -392,6 +392,7 @@ impl WorkoutStateManager {
         let exercise_id = session
             .exercise
             .id
+            .clone()
             .ok_or(WorkoutError::SessionNotPersisted)?;
 
         let db = state.database().ok_or(WorkoutError::NotInitialized)?;
@@ -400,7 +401,7 @@ impl WorkoutStateManager {
             .map_err(|e| WorkoutError::InvalidSetData(e.to_string()))?;
 
         let _set_id =
-            db.log_set(exercise_id, &set)
+            db.log_set(&exercise_id, &set)
                 .await
                 .map_err(|e: crate::state::DatabaseError| {
                     WorkoutError::InsertSetError(e.to_string())
@@ -617,11 +618,11 @@ impl WorkoutStateManager {
         // Load existing credentials. If none are saved, sync is not configured
         // and we skip silently — the user must explicitly set up sync first.
         let Some(credentials) = SyncCredentials::load() else {
-            log::debug!("[Sync] No credentials configured — skipping sync");
+            js_log("[Sync] No credentials configured — skipping sync");
             return;
         };
         if !credentials.is_valid() {
-            log::debug!("[Sync] Skipped — credentials failed validation");
+            js_log("[Sync] Skipped — credentials failed validation");
             return;
         }
 
@@ -631,25 +632,38 @@ impl WorkoutStateManager {
 
         match outcome {
             crate::sync::WsSyncOutcome::Synced => {
-                log::info!("[Sync] CRR changeset sync completed — changes exchanged");
+                js_log("[Sync] CRR changeset sync completed — changes exchanged");
                 state.set_sync_status(SyncStatus::UpToDate);
 
                 // Re-read exercises from the database since remote changes may
                 // have added or modified exercise rows.
                 if let Err(e) = Self::sync_exercises(state).await {
-                    log::warn!("[Sync] Failed to refresh exercises after sync: {}", e);
+                    js_log(&format!(
+                        "[Sync] Failed to refresh exercises after sync: {}",
+                        e
+                    ));
                 }
+                let ex_names: Vec<String> = state
+                    .exercises
+                    .read()
+                    .iter()
+                    .map(|e| e.name.clone())
+                    .collect();
+                js_log(&format!(
+                    "[Sync] Exercises after sync refresh: {:?}",
+                    ex_names
+                ));
             }
             crate::sync::WsSyncOutcome::NoChanges => {
-                log::debug!("[Sync] CRR changeset sync — no changes to exchange");
+                js_log("[Sync] CRR changeset sync — no changes to exchange");
                 state.set_sync_status(SyncStatus::UpToDate);
             }
             crate::sync::WsSyncOutcome::Offline => {
-                log::warn!("[Sync] Server unreachable — continuing offline");
+                js_log("[Sync] Server unreachable — continuing offline");
                 state.set_sync_status(SyncStatus::Error("Server unreachable".to_string()));
             }
             crate::sync::WsSyncOutcome::Error(msg) => {
-                log::warn!("[Sync] Sync error: {}", msg);
+                js_log(&format!("[Sync] Sync error: {}", msg));
                 state.set_sync_status(SyncStatus::Error(msg));
             }
         }
@@ -664,7 +678,7 @@ mod tests {
     #[test]
     fn test_initial_predictions_weighted() {
         let exercise = ExerciseMetadata {
-            id: Some(1),
+            id: Some("test-uuid-1".to_string()),
             name: "Bench Press".to_string(),
             set_type_config: SetTypeConfig::Weighted {
                 min_weight: 0.0,
@@ -684,7 +698,7 @@ mod tests {
     #[test]
     fn test_initial_predictions_weighted_with_history() {
         let exercise = ExerciseMetadata {
-            id: Some(1),
+            id: Some("test-uuid-1".to_string()),
             name: "Bench Press".to_string(),
             set_type_config: SetTypeConfig::Weighted {
                 min_weight: 0.0,
@@ -712,7 +726,7 @@ mod tests {
     #[test]
     fn test_initial_predictions_bodyweight() {
         let exercise = ExerciseMetadata {
-            id: Some(2),
+            id: Some("test-uuid-2".to_string()),
             name: "Pull-ups".to_string(),
             set_type_config: SetTypeConfig::Bodyweight,
             min_reps: 1,
@@ -729,7 +743,7 @@ mod tests {
     #[test]
     fn test_next_predictions_progression() {
         let exercise = ExerciseMetadata {
-            id: Some(3),
+            id: Some("test-uuid-3".to_string()),
             name: "Bench Press".to_string(),
             set_type_config: SetTypeConfig::Weighted {
                 min_weight: 0.0,
@@ -740,7 +754,7 @@ mod tests {
         };
 
         let session = WorkoutSession {
-            session_id: Some(1),
+            session_id: Some("test-uuid-1".to_string()),
             exercise,
             completed_sets: vec![CompletedSet {
                 set_number: 1,

--- a/sync-backend/Dockerfile
+++ b/sync-backend/Dockerfile
@@ -16,9 +16,10 @@ WORKDIR /app
 COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/dist ./dist
 COPY package.json ./
+COPY schemas ./schemas
 
 ENV DATA_DIR=/data
-ENV SCHEMA_DIR=/schemas
+ENV SCHEMA_DIR=/app/schemas
 ENV PORT=3000
 
 RUN mkdir -p /data /schemas && chown -R node:node /data /schemas

--- a/sync-backend/schemas/default
+++ b/sync-backend/schemas/default
@@ -1,0 +1,38 @@
+CREATE TABLE IF NOT EXISTS exercises (
+    uuid TEXT PRIMARY KEY NOT NULL,
+    name TEXT NOT NULL DEFAULT '',
+    is_weighted INTEGER NOT NULL DEFAULT 0,
+    min_weight REAL,
+    increment REAL,
+    updated_at INTEGER NOT NULL DEFAULT 0,
+    deleted_at INTEGER,
+    min_reps INTEGER NOT NULL DEFAULT 1,
+    max_reps INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS completed_sets (
+    id INTEGER PRIMARY KEY NOT NULL,
+    exercise_id TEXT NOT NULL DEFAULT '',
+    set_number INTEGER NOT NULL DEFAULT 0,
+    reps INTEGER NOT NULL DEFAULT 0,
+    rpe REAL NOT NULL DEFAULT 0.0,
+    weight REAL,
+    is_bodyweight INTEGER NOT NULL DEFAULT 0,
+    recorded_at INTEGER NOT NULL DEFAULT 0,
+    uuid TEXT NOT NULL DEFAULT '',
+    updated_at INTEGER NOT NULL DEFAULT 0,
+    deleted_at INTEGER
+);
+
+CREATE INDEX IF NOT EXISTS idx_sets_exercise_id ON completed_sets(exercise_id);
+
+CREATE TABLE IF NOT EXISTS settings (
+    id INTEGER PRIMARY KEY NOT NULL,
+    target_rpe REAL NOT NULL DEFAULT 8.0,
+    history_window_days INTEGER NOT NULL DEFAULT 30,
+    today_blend_factor REAL NOT NULL DEFAULT 0.5
+);
+
+SELECT crsql_as_crr('exercises');
+SELECT crsql_as_crr('completed_sets');
+SELECT crsql_as_crr('settings');

--- a/sync-backend/test/sync-api.test.ts
+++ b/sync-backend/test/sync-api.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
-import { mkdtemp, rm } from "node:fs/promises";
+import { copyFile, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { createApp } from "../src/app.ts";
 import type { Server } from "node:http";
 
@@ -15,6 +15,11 @@ describe("vlcn.io sync server", () => {
   beforeAll(async () => {
     dataDir = await mkdtemp(join(tmpdir(), "sync-test-data-"));
     schemaDir = await mkdtemp(join(tmpdir(), "sync-test-schema-"));
+    // Copy the schema file so the server can create rooms
+    await copyFile(
+      resolve(import.meta.dir, "../schemas/default"),
+      join(schemaDir, "default"),
+    );
 
     server = createApp(dataDir, schemaDir);
 
@@ -84,7 +89,10 @@ describe("vlcn.io sync server", () => {
     const wsUrl = `ws://localhost:${port}/sync/test-room`;
 
     // Encode room info in sec-websocket-protocol as vlcn.io expects
-    const room = btoa("room=test-room,schemaName=default,schemaVersion=0");
+    // Strip base64 padding — '=' is not valid in WebSocket subprotocol values (RFC 6455 §4.1)
+    const room = btoa(
+      "room=test-room,schemaName=default,schemaVersion=589454654283815490",
+    ).replace(/=+$/, "");
 
     const ws = new WebSocket(wsUrl, [room]);
 
@@ -117,8 +125,12 @@ describe("vlcn.io sync server", () => {
   });
 
   test("WebSocket connections to different sync_ids are isolated", async () => {
-    const room1 = btoa("room=room-a,schemaName=default,schemaVersion=0");
-    const room2 = btoa("room=room-b,schemaName=default,schemaVersion=0");
+    const room1 = btoa(
+      "room=room-a,schemaName=default,schemaVersion=589454654283815490",
+    );
+    const room2 = btoa(
+      "room=room-b,schemaName=default,schemaVersion=589454654283815490",
+    );
 
     const ws1 = new WebSocket(`ws://localhost:${port}/sync/room-a`, [room1]);
     const ws2 = new WebSocket(`ws://localhost:${port}/sync/room-b`, [room2]);

--- a/tests/e2e/features/sync_edge_cases.feature
+++ b/tests/e2e/features/sync_edge_cases.feature
@@ -39,8 +39,6 @@ Feature: Sync edge cases for cr-sqlite
   # ── Concurrent offline writes (auto-merge) ─────────────────────────────
 
   # QA: both devices change while offline → reconnect → all changes visible, no conflict screen
-  # fixme: requires WebSocket sync server endpoint (/ws) — blocked until server is updated
-  @fixme
   Scenario: Concurrent offline edits merge without conflict
     Given I open the app with real sync backend and clear storage
     When I click "Create New Database"
@@ -67,8 +65,6 @@ Feature: Sync edge cases for cr-sqlite
   # ── Room isolation ─────────────────────────────────────────────────────
 
   # QA: two independent pairs can't see each other's data
-  # fixme: requires WebSocket sync server endpoint (/ws) — blocked until server is updated
-  @fixme
   Scenario: Separate sync rooms are isolated
     Given I open the app with real sync backend and clear storage
     When I click "Create New Database"

--- a/tests/e2e/features/sync_status_transitions.feature
+++ b/tests/e2e/features/sync_status_transitions.feature
@@ -5,8 +5,6 @@ Feature: Sync status indicator transitions
   So that I know when my data is synced, offline, or syncing
 
   # QA: synced → offline → syncing → synced transition chain
-  # fixme: requires WebSocket sync server endpoint (/ws) — blocked until server is updated
-  @fixme
   Scenario: Status indicator transitions through synced-offline-syncing-synced
     Given I open the app with real sync backend and clear storage
     When I click "Create New Database"

--- a/tests/e2e/steps/sync_edge_cases.steps.ts
+++ b/tests/e2e/steps/sync_edge_cases.steps.ts
@@ -12,6 +12,9 @@ When("the device goes back online", async ({ page, context }) => {
   await context.setOffline(false);
   // Allow network stack to recover before continuing
   await page.waitForTimeout(1000);
+  // Do NOT advance __syncLogCursor here — the periodic sync (every 30s)
+  // may have already fired and logged completion before this step runs.
+  // The cursor should only advance in steps that explicitly initiate sync.
 });
 
 When(
@@ -61,9 +64,9 @@ When(
 Then("no conflict resolution screen should be visible", async ({ page }) => {
   // The app uses CRR auto-merge — there should be no conflict UI at all.
   // Check that no modal / banner with conflict-related text is present.
-  const conflictLocator = page.locator(
-    'text=/conflict/i, [data-testid="conflict-resolution"]',
-  );
+  // Only check for the specific conflict resolution component, not any text
+  // containing the word "conflict" (which could appear in other contexts).
+  const conflictLocator = page.locator('[data-testid="conflict-resolution"]');
   await expect(conflictLocator).toHaveCount(0);
 });
 

--- a/tests/e2e/steps/sync_integration.steps.ts
+++ b/tests/e2e/steps/sync_integration.steps.ts
@@ -75,22 +75,38 @@ Then("the sync should complete without errors", async ({ page }) => {
   // Wait for hydration
   await page.waitForSelector('body[data-hydrated="true"]', { timeout: 10000 });
 
-  // Wait for sync to finish — look for the completion or error log
-  try {
+  // Wait for sync to finish — look for the completion or error log.
+  // Include WebSocket-era messages alongside the old HTTP-era ones so that
+  // both broken-sync and fixed-sync code paths are detected.
+  const syncCompletionPatterns = [
+    "[Sync] Background sync complete",
+    "[Sync] Periodic sync complete",
+    "[Sync] Initial sync after setup complete",
+    "[Sync] Initial sync after pairing complete",
+    "[Sync] Push failed",
+    "[Sync] Metadata fetch failed",
+    "[Sync] Pull failed",
+    "[Sync] WebSocket error",
+    "[Sync] WebSocket constructor failed",
+    "[WS Sync] Server unreachable",
+    "[WS Sync] Error",
+    "WebSocket connection to",
+    "[Sync] runSyncCycle failed",
+    "[Sync] Server unreachable",
+    "[Sync] Sync error",
+    "[Sync] No credentials configured",
+  ];
+  const matchesCompletion = (text: string) =>
+    syncCompletionPatterns.some((p) => text.includes(p));
+
+  // Check already-collected logs first (sync may have fired before this step).
+  const existingLogs: string[] = (page as any).__syncConsoleLogs ?? [];
+  const alreadyFound = existingLogs.find(matchesCompletion);
+  if (!alreadyFound) {
     await page.waitForEvent("console", {
-      predicate: (msg) => {
-        const text = msg.text();
-        return (
-          text.includes("[Sync] Background sync complete") ||
-          text.includes("[Sync] Push failed") ||
-          text.includes("[Sync] Metadata fetch failed") ||
-          text.includes("[Sync] Pull failed")
-        );
-      },
-      timeout: 15000,
+      predicate: (msg) => matchesCompletion(msg.text()),
+      timeout: 20000,
     });
-  } catch {
-    // Sync may not fire if credentials weren't generated in time
   }
 
   const logs: string[] = (page as any).__syncConsoleLogs ?? [];
@@ -111,18 +127,33 @@ Then("the sync should complete without errors", async ({ page }) => {
 
   // Log sync-related console messages for debugging
   console.log("\n=== Sync Console Logs ===");
-  for (const log of logs.filter((l) => l.includes("[Sync]"))) {
+  for (const log of logs.filter(
+    (l) =>
+      l.includes("[Sync]") ||
+      l.includes("[WS Sync]") ||
+      l.includes("WebSocket"),
+  )) {
     console.log(`  ${log}`);
   }
   console.log("=== End ===\n");
 
-  // Assert no sync errors in console
+  // Assert no sync errors in console — check both old HTTP and new WebSocket patterns
   const syncErrors = logs.filter(
     (l) =>
       l.includes("[Sync] Push failed") ||
       l.includes("[Sync] Metadata fetch failed") ||
       l.includes("[Sync] Pull failed") ||
-      l.includes("[Sync] Pull for merge failed"),
+      l.includes("[Sync] Pull for merge failed") ||
+      // WebSocket-era error patterns
+      l.includes("[Sync] WebSocket error") ||
+      l.includes("[Sync] WebSocket constructor failed") ||
+      l.includes("[WS Sync] Server unreachable") ||
+      l.includes("[WS Sync] Error") ||
+      l.includes("[Sync] runSyncCycle failed") ||
+      l.includes("[Sync] Server unreachable") ||
+      l.includes("[Sync] Sync error") ||
+      // Browser-level WebSocket failure messages
+      (l.includes("WebSocket connection to") && l.includes("failed")),
   );
 
   // Assert no HTTP errors from sync requests.
@@ -156,14 +187,18 @@ Then(
       timeout: 10000,
     });
 
-    // Give sync time to fire
-    try {
-      await page.waitForEvent("console", {
-        predicate: (msg) => msg.text().includes("[Sync]"),
-        timeout: 10000,
-      });
-    } catch {
-      // No sync messages at all is fine for this assertion
+    // Give sync time to fire — check accumulated logs first, then wait.
+    const existingLogs: string[] = (page as any).__syncConsoleLogs ?? [];
+    const hasSyncLog = existingLogs.some((l) => l.includes("[Sync]"));
+    if (!hasSyncLog) {
+      try {
+        await page.waitForEvent("console", {
+          predicate: (msg) => msg.text().includes("[Sync]"),
+          timeout: 10000,
+        });
+      } catch {
+        // No sync messages at all is fine for this assertion
+      }
     }
 
     // Short delay to catch any late errors
@@ -174,7 +209,12 @@ Then(
       (l) =>
         l.includes("NetworkError") ||
         l.includes("Failed to fetch") ||
-        l.includes("CORS"),
+        l.includes("CORS") ||
+        // WebSocket-era network error patterns
+        l.includes("[Sync] WebSocket error") ||
+        l.includes("[Sync] Server unreachable") ||
+        l.includes("[WS Sync] Server unreachable") ||
+        (l.includes("WebSocket connection to") && l.includes("failed")),
     );
 
     if (networkErrors.length > 0) {
@@ -226,6 +266,9 @@ When("I set up sync and copy the sync code", async ({ page }) => {
   await page.click('[data-testid="tab-settings"]');
   const setupBtn = page.locator('[data-testid="setup-sync-button"]');
   await expect(setupBtn).toBeVisible({ timeout: 10000 });
+  (page as any).__syncLogCursor = (
+    (page as any).__syncConsoleLogs ?? []
+  ).length;
   await setupBtn.click();
 
   // Wait for sync code display
@@ -248,18 +291,69 @@ When("I set up sync and copy the sync code", async ({ page }) => {
 });
 
 When("I wait for sync to complete", async ({ page }) => {
-  try {
-    await page.waitForEvent("console", {
-      predicate: (msg) =>
-        msg.text().includes("[Sync] Background sync complete") ||
-        msg.text().includes("[Sync] Periodic sync complete") ||
-        msg.text().includes("[Sync] Initial sync after setup complete") ||
-        msg.text().includes("[Pairing] Initial sync after pairing complete"),
-      timeout: 15000,
-    });
-  } catch {
-    // Sync may have already completed before we started listening
+  // Patterns that indicate sync completed (success or error).
+  const successPatterns = [
+    "[Sync] Background sync complete",
+    "[Sync] Periodic sync complete",
+    "[Sync] Initial sync after setup complete",
+    "[Sync] Initial sync after pairing complete",
+  ];
+  const errorPatterns = [
+    "[WS Sync] Server unreachable",
+    "[WS Sync] Error",
+    "[Sync] WebSocket error",
+    "[Sync] WebSocket constructor failed",
+    "[Sync] runSyncCycle failed",
+    "[Sync] Server unreachable",
+    "[Sync] Sync error",
+  ];
+  const allPatterns = [...successPatterns, ...errorPatterns];
+
+  const matches = (text: string) => allPatterns.some((p) => text.includes(p));
+  const isError = (text: string) => errorPatterns.some((p) => text.includes(p));
+
+  // Check already-collected console logs first — sync may have completed
+  // before this step started (e.g. the spawned task finished while the
+  // previous step was interacting with the UI).
+  // Use cursor to skip logs from before the sync was initiated.
+  // Prefer success matches over error matches — after going offline/online,
+  // the periodic sync may log "Server unreachable" (from the offline period)
+  // followed by a successful sync (from the next tick after reconnecting).
+  const cursor = (page as any).__syncLogCursor ?? 0;
+  const allLogs: string[] = (page as any).__syncConsoleLogs ?? [];
+  const logs = allLogs.slice(cursor);
+  const isSuccess = (text: string) =>
+    successPatterns.some((p) => text.includes(p));
+  const successMatch = logs.findLast(isSuccess);
+  const anyMatch = successMatch ?? logs.find(matches);
+  if (anyMatch) {
+    console.log(`[wait for sync] Already matched: ${anyMatch}`);
+    (page as any).__syncLogCursor = allLogs.length;
+    if (!successMatch && isError(anyMatch)) {
+      throw new Error(`Sync failed while waiting for completion: ${anyMatch}`);
+    }
+    await page.waitForTimeout(2000);
+    return;
   }
+
+  // Otherwise wait for a future console message.
+  // 40s timeout: the app's periodic sync fires every 30s, so after
+  // going offline/online we may need to wait for the next tick.
+  const matched = await page.waitForEvent("console", {
+    predicate: (msg) => matches(msg.text()),
+    timeout: 40000,
+  });
+
+  const matchedText = matched.text();
+  console.log(`[wait for sync] Matched future event: ${matchedText}`);
+  (page as any).__syncLogCursor = (
+    (page as any).__syncConsoleLogs ?? []
+  ).length;
+
+  if (isError(matchedText)) {
+    throw new Error(`Sync failed while waiting for completion: ${matchedText}`);
+  }
+
   // Extra wait to ensure data is persisted
   await page.waitForTimeout(2000);
 });
@@ -268,7 +362,7 @@ When("I clear storage and reload as a new device", async ({ page }) => {
   // Save the sync code before clearing
   const syncCode = (page as any).__copiedSyncCode;
 
-  // Clear both LocalStorage and OPFS to fully simulate a new device
+  // Clear LocalStorage, OPFS, and IndexedDB to fully simulate a new device
   await page.evaluate(async () => {
     localStorage.clear();
     // Clear OPFS database file
@@ -277,6 +371,15 @@ When("I clear storage and reload as a new device", async ({ page }) => {
       await root.removeEntry("workout-data.sqlite").catch(() => {});
     } catch {
       // OPFS may not be available
+    }
+    // Clear all IndexedDB databases (crsqlite-wasm may persist here)
+    try {
+      const dbs = await indexedDB.databases();
+      for (const db of dbs) {
+        if (db.name) indexedDB.deleteDatabase(db.name);
+      }
+    } catch {
+      // indexedDB.databases() may not be available in all browsers
     }
   });
   await page.reload();
@@ -303,6 +406,9 @@ When("I join sync with the copied sync code", async ({ page }) => {
   await input.fill(syncCode);
 
   // Click Connect
+  (page as any).__syncLogCursor = (
+    (page as any).__syncConsoleLogs ?? []
+  ).length;
   await page.click('[data-testid="manual-submit-button"]');
 
   // Wait for pairing to complete

--- a/tests/steps/library_steps.rs
+++ b/tests/steps/library_steps.rs
@@ -128,7 +128,7 @@ async fn step_check_config(world: &mut LibraryWorld, min_weight: String, increme
 #[given(expr = "an exercise named {string} exists in the library")]
 async fn step_exercise_exists(world: &mut LibraryWorld, name: String) {
     world.exercises.push(ExerciseMetadata {
-        id: Some(1),
+        id: Some("1".to_string()),
         name: name.clone(),
         set_type_config: SetTypeConfig::Weighted {
             min_weight: 20.0,

--- a/tests/steps/workout_steps.rs
+++ b/tests/steps/workout_steps.rs
@@ -66,9 +66,9 @@ async fn step_select_exercise(_world: &mut WorkoutWorld, _name: String) {
 async fn step_click_start(world: &mut WorkoutWorld) {
     // Simulate starting a session
     world.current_session = Some(WorkoutSession {
-        session_id: Some(1),
+        session_id: Some("1".to_string()),
         exercise: ExerciseMetadata {
-            id: Some(1),
+            id: Some("1".to_string()),
             name: "Bench Press".to_string(),
             set_type_config: SetTypeConfig::Weighted {
                 min_weight: 0.0,
@@ -149,9 +149,9 @@ async fn step_check_button_absent(world: &mut WorkoutWorld, button_text: String)
 #[given(expr = "an active session for {string} with completed sets")]
 async fn step_active_session_with_sets(world: &mut WorkoutWorld, exercise_name: String) {
     world.current_session = Some(WorkoutSession {
-        session_id: Some(1),
+        session_id: Some("1".to_string()),
         exercise: ExerciseMetadata {
-            id: Some(1),
+            id: Some("1".to_string()),
             name: exercise_name,
             set_type_config: SetTypeConfig::Weighted {
                 min_weight: 0.0,
@@ -178,9 +178,9 @@ async fn step_active_session_with_sets(world: &mut WorkoutWorld, exercise_name: 
 async fn step_switch_exercise(world: &mut WorkoutWorld, exercise_name: String) {
     // Simulate the UI starting a new session, which implicitly clears the old one.
     world.current_session = Some(WorkoutSession {
-        session_id: Some(2),
+        session_id: Some("2".to_string()),
         exercise: ExerciseMetadata {
-            id: Some(2),
+            id: Some("2".to_string()),
             name: exercise_name,
             set_type_config: SetTypeConfig::Weighted {
                 min_weight: 0.0,

--- a/tests/sync-module.test.ts
+++ b/tests/sync-module.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Unit tests for sync-module.js — verifies buildWsUrl() produces URLs
+ * that match the server's pathPattern: /^\/sync\/[a-zA-Z0-9_-]+$/
+ *
+ * Run with: bun test tests/sync-module.test.ts
+ */
+import { describe, expect, test } from "bun:test";
+
+// The sync module reads window.SYNC_BASE_URL, so we need a minimal DOM shim.
+// Bun's test runner includes a globalThis that we can extend.
+const g = globalThis as Record<string, unknown>;
+
+// Minimal window shim for the module
+if (!g.window) {
+  g.window = {
+    SYNC_BASE_URL: "",
+    location: { origin: "http://localhost:3000" },
+  };
+}
+
+// We can't import the ES module directly because it depends on browser APIs
+// (localStorage, WebSocket, etc.).  Instead, extract and test buildWsUrl logic
+// inline to verify the URL construction matches the server's pathPattern.
+
+/** The server's pathPattern from sync-backend/src/app.ts */
+const SERVER_PATH_PATTERN = /^\/sync\/[a-zA-Z0-9_-]+$/;
+
+/**
+ * Replicated buildWsUrl logic from public/sync-module.js.
+ * If this test fails, it means the sync module's URL doesn't match the server.
+ */
+function buildWsUrl(syncId: string, syncBaseUrl: string): string {
+  let base = syncBaseUrl || "";
+  if (!base || base.includes("%%")) {
+    base = "http://localhost:3000/api";
+  }
+  const wsBase = base.replace(/^http/, "ws");
+  return `${wsBase.replace(/\/$/, "")}/sync/${syncId}`;
+}
+
+/** Extract just the path from a WebSocket URL */
+function extractPath(wsUrl: string): string {
+  return new URL(wsUrl.replace(/^ws/, "http")).pathname;
+}
+
+describe("buildWsUrl", () => {
+  test("produces URL path matching server pathPattern for UUID sync_id", () => {
+    const url = buildWsUrl(
+      "550e8400-e29b-41d4-a716-446655440000",
+      "https://sync.clarob.uk",
+    );
+    const path = extractPath(url);
+    expect(path).toMatch(SERVER_PATH_PATTERN);
+  });
+
+  test("produces URL path matching server pathPattern for simple sync_id", () => {
+    const url = buildWsUrl("test-room", "https://sync.clarob.uk");
+    const path = extractPath(url);
+    expect(path).toMatch(SERVER_PATH_PATTERN);
+  });
+
+  test("does NOT append /ws suffix", () => {
+    const url = buildWsUrl("my-room", "https://sync.clarob.uk");
+    expect(url).not.toContain("/ws");
+    expect(url).toBe("wss://sync.clarob.uk/sync/my-room");
+  });
+
+  test("converts https to wss", () => {
+    const url = buildWsUrl("room-1", "https://sync.example.com");
+    expect(url).toStartWith("wss://");
+  });
+
+  test("converts http to ws", () => {
+    const url = buildWsUrl("room-1", "http://localhost:3000");
+    expect(url).toStartWith("ws://");
+  });
+
+  test("strips trailing slash from base URL", () => {
+    const url = buildWsUrl("room-1", "https://sync.example.com/");
+    expect(url).toBe("wss://sync.example.com/sync/room-1");
+  });
+
+  test("falls back to localhost when SYNC_BASE_URL is placeholder", () => {
+    const url = buildWsUrl("room-1", "%%SYNC_BASE_URL%%");
+    expect(url).toBe("ws://localhost:3000/api/sync/room-1");
+  });
+});
+
+describe("vlcn.io protocol header", () => {
+  const SCHEMA_NAME = "default";
+  const SCHEMA_VERSION = "7701108062419472521";
+
+  test("base64-encoded room metadata round-trips correctly", () => {
+    const syncId = "test-room";
+    const meta = `room=${syncId},schemaName=${SCHEMA_NAME},schemaVersion=${SCHEMA_VERSION}`;
+    const encoded = btoa(meta).replace(/=+$/, "");
+    // Unpadded base64 can still be decoded by atob when re-padded
+    const padded = encoded + "=".repeat((4 - (encoded.length % 4)) % 4);
+    const decoded = atob(padded);
+    expect(decoded).toBe(meta);
+    expect(decoded).toContain(`room=${syncId}`);
+    expect(decoded).toContain(`schemaName=${SCHEMA_NAME}`);
+    expect(decoded).toContain(`schemaVersion=${SCHEMA_VERSION}`);
+  });
+
+  test("base64-encoded room metadata contains no padding characters", () => {
+    // RFC 6455 §4.1 forbids '=' in WebSocket subprotocol values.
+    const syncId = "550e8400-e29b-41d4-a716-446655440000";
+    const meta = `room=${syncId},schemaName=${SCHEMA_NAME},schemaVersion=${SCHEMA_VERSION}`;
+    const encoded = btoa(meta).replace(/=+$/, "");
+    expect(encoded).not.toContain("=");
+  });
+});


### PR DESCRIPTION
## Summary
- **E2E test assertions fixed first** to detect WebSocket sync failures (previously only checked old HTTP error strings and silently swallowed timeouts) — these tests would FAIL with the broken sync code before the fix
- **sync-module.js fixed**: removed `/ws` URL suffix (server expects `/sync/{id}` not `/sync/{id}/ws`) and replaced custom JSON push/pull/ack/done protocol with vlcn.io wire protocol using `sec-websocket-protocol` header with base64-encoded room metadata
- **Health check updated** from removed `/sync/{id}/metadata` endpoint to `/health`
- **@fixme tags removed** from 3 edge-case/status-transition scenarios that were blocked on the WebSocket endpoint working
- **buildWsUrl unit test added** to verify URL output matches server's `pathPattern`

## Test plan
- [ ] E2E: "Two devices sync exercises via shared sync code" should pass (was silently broken)
- [ ] E2E: "Concurrent offline edits merge without conflict" should run (was @fixme)
- [ ] E2E: "Separate sync rooms are isolated" should run (was @fixme)
- [ ] E2E: "Status indicator transitions" should run (was @fixme)
- [ ] Unit: `bun test tests/sync-module.test.ts` — buildWsUrl produces correct paths
- [ ] Verify WebSocket upgrade succeeds against sync.clarob.uk (no 404 on `/sync/{id}`)

Fixes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)