### PR TITLE
feat: sync-backend image to Forgejo container registry

### DIFF
--- a/.forgejo/workflows/sync-backend-image.yml
+++ b/.forgejo/workflows/sync-backend-image.yml
@@ -1,0 +1,39 @@
+name: Build and Push Sync Backend Image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "sync-backend/**"
+  workflow_dispatch:
+
+env:
+  REGISTRY: forgejo.clarob.uk
+  IMAGE_NAME: ${{ gitea.repository_owner }}/sync-backend
+
+jobs:
+  build-and-push:
+    runs-on: docker
+    container:
+      image: catthehacker/ubuntu:act-latest
+      volumes:
+        - /var/run/docker.sock:/var/run/docker.sock
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Log in to Forgejo container registry
+        run: echo "${{ secrets.FORGEJO_TOKEN }}" | docker login "${{ env.REGISTRY }}" -u "${{ gitea.actor }}" --password-stdin
+
+      - name: Set short SHA
+        id: sha
+        run: echo "short=$(echo '${{ gitea.sha }}' | cut -c1-7)" >> "$GITHUB_OUTPUT"
+
+      - name: Build Docker image
+        run: docker build -t "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.sha.outputs.short }}" -t "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest" sync-backend
+
+      - name: Push Docker image
+        run: |
+          docker push "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.sha.outputs.short }}"
+          docker push "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest"


### PR DESCRIPTION
## Summary
- Add `.forgejo/workflows/sync-backend-image.yml` that builds and pushes the sync-backend Docker image to the Forgejo built-in container registry (`forgejo.clarob.uk/<owner>/sync-backend`)
- Triggered on push to `main` when `sync-backend/**` files change (plus `workflow_dispatch`)
- Uses Docker socket mount (`/var/run/docker.sock`) for building images on the Forgejo runner
- Authenticates via `FORGEJO_TOKEN` secret and `gitea.actor` context
- Tags images with both 7-char commit SHA and `latest`

## Acceptance criteria from #202
- [x] `.forgejo/workflows/sync-backend-image.yml` exists
- [x] Triggered on push to main when `sync-backend/` files change
- [x] Image pushed to `forgejo.clarob.uk/<owner>/sync-backend`
- [x] Image tagged with commit SHA and `latest`
- [x] Authentication uses `FORGEJO_TOKEN`

## Test plan
- [ ] Verify workflow YAML is valid by inspecting Forgejo Actions UI after merge
- [ ] Push a change to `sync-backend/` on main and confirm the image appears in the Forgejo container registry
- [ ] Confirm both SHA and `latest` tags are present on the pushed image
- [ ] Verify `FORGEJO_TOKEN` secret is configured on the Forgejo runner

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)